### PR TITLE
Feature: Add support for populating traits and properties in querystring API

### DIFF
--- a/component.json
+++ b/component.json
@@ -26,6 +26,7 @@
     "ianstormtaylor/callback": "0.0.1",
     "ianstormtaylor/is": "0.1.0",
     "ndhoule/includes": "1.0.0",
+    "ndhoule/foldl": "1.0.3",
     "ndhoule/pick": "1.0.1",
     "segmentio/after": "0.0.1",
     "segmentio/canonical": "0.0.1",

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -14,6 +14,7 @@ var cookie = require('./cookie');
 var debug = require('debug');
 var defaults = require('defaults');
 var each = require('each');
+var foldl = require('foldl');
 var group = require('./group');
 var is = require('is');
 var isMeta = require('is-meta');
@@ -66,7 +67,7 @@ function Analytics() {
   var self = this;
   this.on('initialize', function(settings, options){
     if (options.initialPageview) self.page();
-    self._parseQuery();
+    self._parseQuery(window.location.search);
   });
 }
 
@@ -620,17 +621,44 @@ Analytics.prototype.reset = function(){
 /**
  * Parse the query string for callable methods.
  *
+ * @param {String} query
  * @return {Analytics}
  * @api private
  */
 
-Analytics.prototype._parseQuery = function() {
-  // Identify and track any `ajs_uid` and `ajs_event` parameters in the URL.
-  var q = querystring.parse(window.location.search);
-  if (q.ajs_uid) this.identify(q.ajs_uid);
-  if (q.ajs_event) this.track(q.ajs_event);
+Analytics.prototype._parseQuery = function(query) {
+  // Parse querystring to an object
+  var q = querystring.parse(query);
+  // Create traits and properties objects, populate from querysting params
+  var traits = pickPrefix('ajs_trait_', q);
+  var props = pickPrefix('ajs_prop_', q);
+  // Trigger based on callable parameters in the URL
+  if (q.ajs_uid) this.identify(q.ajs_uid, traits);
+  if (q.ajs_event) this.track(q.ajs_event, props);
   if (q.ajs_aid) user.anonymousId(q.ajs_aid);
   return this;
+
+  /**
+   * Create a shallow copy of an input object containing only the properties
+   * whose keys are specified by a prefix, stripped of that prefix
+   *
+   * @param {String} prefix
+   * @param {Object} object
+   * @return {Object}
+   * @api private
+   */
+
+  function pickPrefix(prefix, object) {
+    var length = prefix.length;
+    var sub;
+    return foldl(function(acc, val, key) {
+      if (key.substr(0, length) === prefix) {
+        sub = key.substr(length);
+        acc[sub] = val;
+      }
+      return acc;
+    }, {}, object);
+  }
 };
 
 /**
@@ -659,4 +687,3 @@ Analytics.prototype.noConflict = function(){
   window.analytics = _analytics;
   return this;
 };
-

--- a/test/analytics.js
+++ b/test/analytics.js
@@ -329,6 +329,46 @@ describe('Analytics', function() {
     });
   });
 
+  describe('#_parseQuery', function() {
+    describe('user settings', function() {
+      beforeEach(function() {
+        sinon.spy(analytics, 'identify');
+      });
+
+      it('should parse `ajs_aid` and set anonymousId', function() {
+        sinon.spy(user, 'anonymousId');
+        analytics._parseQuery('?ajs_aid=123');
+        assert(user.anonymousId.calledWith('123'));
+      });
+
+      it('should parse `ajs_uid` and call identify', function() {
+        analytics._parseQuery('?ajs_uid=123');
+        assert(analytics.identify.calledWith('123', {}));
+      });
+
+      it('should include traits in identify', function() {
+        analytics._parseQuery('?ajs_uid=123&ajs_trait_name=chris');
+        assert(analytics.identify.calledWith('123', { name: 'chris' }));
+      });
+    });
+
+    describe('events', function() {
+      beforeEach(function() {
+        sinon.spy(analytics, 'track');
+      });
+
+      it('should parse `ajs_event` and call track', function() {
+        analytics._parseQuery('?ajs_event=test');
+        assert(analytics.track.calledWith('test', {}));
+      });
+
+      it('should include properties in track', function() {
+        analytics._parseQuery('?ajs_event=Started+Trial&ajs_prop_plan=Silver');
+        assert(analytics.track.calledWith('Started Trial', { plan: 'Silver' }));
+      });
+    });
+  });
+
   describe('#_timeout', function() {
     it('should set the timeout for callbacks', function() {
       analytics.timeout(500);


### PR DESCRIPTION
This PR is to prompt a discussion regarding whether this is a feature we want to add and also regarding implementation.

I'm very open to doing this differently, but I think this is a solid approach / API. Since the existing implementation only allows triggering a **single** event and/or a **single** `identify` call (a querystring can only have one value for a given key), it seems appropriate to keep the existing params as the "triggers" and allow any additional parameters with a given prefix for traits (`ajs_trait_`) and properties (`ajs_prop_`) to "enrich" the calls triggered by `ajs_uid` and `ajs_event`, respectively. I'm happy to change the prefixes as well :)

We have *a lot* of customers who have asked for this. Most importantly, by restricting the functionality of the querystring API to *only* trigger events without the possibility of including properties, we are de facto forcing our users to stuff those properties into the event name itself (`"Clicked Start Silver Plan Trial Email Link"`), breaking our own cardinal rules:

![](https://cloudup.com/cRW9ohjHDtX+)

@ndhoule @reinpk 

(also added tests for the querystring implementation — we didn't have any before)

---

- [ ] docs