### PR TITLE
Try serializing tests to fix Sauce issue

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,5 +9,9 @@ dependencies:
 
 test:
   override:
-    - bin/ci:
-        parallel: true
+    - BROWSER=firefox make test-sauce
+    - BROWSER=safari make test-sauce
+    - BROWSER=ie:11 make test-sauce
+    - BROWSER=ie:10 make test-sauce
+    - BROWSER=ie:9 make test-sauce
+    - BROWSER=ie:8 make test-sauce


### PR DESCRIPTION
Sauce Labs tests have been failing recently because they're all slow and racing to use Sauce Labs, and duo-test doesn't establish a singular Sauce tunnel. Serializing the tests will make them slower for the time being, but will improve reliability.