### PR TITLE
update page defaults search method

### DIFF
--- a/lib/pageDefaults.js
+++ b/lib/pageDefaults.js
@@ -20,7 +20,7 @@ function pageDefaults() {
   return {
     path: canonicalPath(),
     referrer: document.referrer,
-    search: location.search,
+    search: searchPath(),
     title: document.title,
     url: canonicalUrl(location.search)
   };
@@ -53,6 +53,21 @@ function canonicalUrl(search) {
   var url = window.location.href;
   var i = url.indexOf('#');
   return i === -1 ? url : url.slice(0, i);
+}
+
+/**
+ * Return the search path for the page
+ * This is preferable to window.location.search because SPAs
+ * can have a # in the url which will include the query param in
+ * the hash
+ *
+ * @return {string}
+ */
+
+function searchPath() {
+  var url = window.location.href;
+  var u = url.indexOf('?');
+  return u === -1 ? '' : url.slice(u, -1);
 }
 
 /*


### PR DESCRIPTION
This change makes it so that we grab the search parameter from the url directly instead of relying on `window.location.search`.

This was causing problems for users with SPAs with a # in their url structure as query parameters were included in `window.location.hash` instead of `window.location.search`.

@jgershen @sperand-io @ladanazita 