### PR TITLE
Pass options.initialPageview parameters on self invoked page call

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -53,7 +53,15 @@ function Analytics() {
 
   var self = this;
   this.on('initialize', function(settings, options) {
-    if (options.initialPageview) self.page();
+    if (options.initialPageview) {
+      self.page(
+        options.initialPageview.category,
+        options.initialPageview.name,
+        options.initialPageview.properties,
+        options.initialPageview.options,
+        options.initialPageview.callback
+      );
+    }
     self._parseQuery(window.location.search);
   });
 }

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -198,6 +198,27 @@ describe('Analytics', function() {
       analytics.initialize(settings);
     });
 
+    it('should pass options.initialPageview parameters on self invoked page call', function() {
+      var options = {
+        initialPageview: {
+          category: 'pageType',
+          name: 'pageName',
+          properties: { someId: '1234' },
+          options: { option: 'a' },
+          callback: function() {}
+        }
+      };
+      sinon.spy(analytics, 'page');
+      analytics.initialize({}, options);
+      assert(analytics.page.calledWith(
+        options.initialPageview.category,
+        options.initialPageview.name,
+        options.initialPageview.properties,
+        options.initialPageview.options,
+        options.initialPageview.callback
+      ));
+    });
+
     it('should parse the query string', function() {
       sinon.stub(analytics, '_parseQuery');
       analytics.initialize();


### PR DESCRIPTION
Extending self invoked page call from initialize to pass parameters set in initialPageview option configuration. This reduces duplication and removes the need for calling page manually. 