### PR TITLE
Fix plus issue

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -629,10 +629,12 @@ Analytics.prototype._parseQuery = function(query) {
   // Create traits and properties objects, populate from querysting params
   var traits = pickPrefix('ajs_trait_', q);
   var props = pickPrefix('ajs_prop_', q);
+  var ajs_uid = q.ajs_uid.replace(/ /g, '');
+  var aid_uid = q.aid_uid.replace(/ /g, '');
   // Trigger based on callable parameters in the URL
-  if (q.ajs_uid) this.identify(q.ajs_uid, traits);
+  if (ajs_uid) this.identify(ajs_uid, traits);
   if (q.ajs_event) this.track(q.ajs_event, props);
-  if (q.ajs_aid) user.anonymousId(q.ajs_aid);
+  if (ajs_aid) user.anonymousId(ajs_aid);
   return this;
 
   /**

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -630,7 +630,7 @@ Analytics.prototype._parseQuery = function(query) {
   var traits = pickPrefix('ajs_trait_', q);
   var props = pickPrefix('ajs_prop_', q);
   var ajs_uid = q.ajs_uid.replace(/ /g, '+');
-  var aid_uid = q.aid_uid.replace(/ /g, '+');
+  var ajs_aid = q.ajs_aid.replace(/ /g, '+');
   // Trigger based on callable parameters in the URL
   if (ajs_uid) this.identify(ajs_uid, traits);
   if (q.ajs_event) this.track(q.ajs_event, props);

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -629,8 +629,8 @@ Analytics.prototype._parseQuery = function(query) {
   // Create traits and properties objects, populate from querysting params
   var traits = pickPrefix('ajs_trait_', q);
   var props = pickPrefix('ajs_prop_', q);
-  var ajs_uid = q.ajs_uid.replace(/ /g, '%2B');
-  var aid_uid = q.aid_uid.replace(/ /g, '%2B');
+  var ajs_uid = q.ajs_uid.replace(/ /g, '+');
+  var aid_uid = q.aid_uid.replace(/ /g, '+');
   // Trigger based on callable parameters in the URL
   if (ajs_uid) this.identify(ajs_uid, traits);
   if (q.ajs_event) this.track(q.ajs_event, props);

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -629,8 +629,8 @@ Analytics.prototype._parseQuery = function(query) {
   // Create traits and properties objects, populate from querysting params
   var traits = pickPrefix('ajs_trait_', q);
   var props = pickPrefix('ajs_prop_', q);
-  var ajs_uid = q.ajs_uid.replace(/ /g, '');
-  var aid_uid = q.aid_uid.replace(/ /g, '');
+  var ajs_uid = q.ajs_uid.replace(/ /g, '%2B');
+  var aid_uid = q.aid_uid.replace(/ /g, '%2B');
   // Trigger based on callable parameters in the URL
   if (ajs_uid) this.identify(ajs_uid, traits);
   if (q.ajs_event) this.track(q.ajs_event, props);


### PR DESCRIPTION
From a customer...

```
we are running into problems identifying people using the query-sting api and the email “plus” trick.
for example:  ?ajs_uid=test+1@test.com
becomes: “test 1@test.com”
which then fails in the mailchimp integration. mailchimp will would only accept test%2B1@test.com
```

Here I'm replacing the space that [component/querystring](https://github.com/component/querystring/blob/master/index.js#L37) puts in for a plus sign.
