### PR TITLE
Add support for default context

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -548,7 +548,7 @@ Analytics.prototype.debug = function(str) {
 
 Analytics.prototype._options = function(options) {
   options = options || {};
-  this.options = options;
+  options = this.options = defaults(this.options || {}, options);
   cookie.options(options.cookie);
   store.options(options.localStorage);
   user.options(options.user);

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -670,6 +670,9 @@ Analytics.prototype.normalize = function(msg) {
   if (msg.anonymousId) user.anonymousId(msg.anonymousId);
   msg.anonymousId = user.anonymousId();
 
+  // Copy default context data
+  msg.context = defaults({}, this.options.context || {}, msg.context);
+
   // Ensure all outgoing requests include page data in their contexts.
   msg.context.page = defaults(msg.context.page || {}, pageDefaults());
 

--- a/lib/pageDefaults.js
+++ b/lib/pageDefaults.js
@@ -67,7 +67,7 @@ function canonicalUrl(search) {
 function searchPath() {
   var url = window.location.href;
   var u = url.indexOf('?');
-  return u === -1 ? '' : url.slice(u, -1);
+  return u === -1 ? '' : url.slice(u);
 }
 
 /*

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -330,6 +330,13 @@ describe('Analytics', function() {
       analytics._options({ group: { option: true } });
       assert(group.options.calledWith({ option: true }));
     });
+
+    it('should merge options on multiple calls', function() {
+      analytics._options({ group: { option: true } });
+      analytics._options({ user: { option: true } });
+      assert(analytics.options.user.option);
+      assert(analytics.options.group.option);
+    });
   });
 
   describe('#_parseQuery', function() {

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -1494,4 +1494,30 @@ describe('Analytics', function() {
       assert.deepEqual({}, group.traits());
     });
   });
+
+  describe('#normalize', function() {
+    describe('context handling', function() {
+      beforeEach(function() {
+        analytics.options.context = {
+          sessionId: '12345'
+        };
+      });
+
+      it('should copy in the default context', function() {
+        var msg = analytics.normalize({
+          properties: {},
+          options: {
+            context: {
+              alarm: true
+            }
+          }
+        });
+
+        var ctx = msg.context || {};
+
+        assert.equal(ctx.alarm, true);
+        assert.equal(ctx.sessionId, '12345');
+      });
+    });
+  });
 });


### PR DESCRIPTION
This PR implements the changes needed in analytics.js-core to support a default context object as described by @gjohnson in #26. I've changed the `_options` method to merge in options with `this.options` on multiple calls, and I've changed the `Analytics.normalize` method to copy properties from `this.options.context`, giving priority to whatever context properties integrations set. Went back and forth on whether or not that should be a deep merge and decided to leave it shallow for now since my use case only needs a shallow merge.

