### PR TITLE
fix stripping last character of query string

### DIFF
--- a/lib/pageDefaults.js
+++ b/lib/pageDefaults.js
@@ -67,7 +67,7 @@ function canonicalUrl(search) {
 function searchPath() {
   var url = window.location.href;
   var u = url.indexOf('?');
-  return u === -1 ? '' : url.slice(u, -1);
+  return u === -1 ? '' : url.slice(u);
 }
 
 /*


### PR DESCRIPTION
The existing implementation of the `searchPath` function will strip the last character of the URL query string. For example, given a url of "http://a-website.com/?hello=there," the existing function will return "?hello=ther". The fix in this PR is simple: it calls `url.slice(u)` instead of `url.slice(u, -1)`, which will end the slice before character -1, which is the last character in the string.