### PR TITLE
Add try catch to initialize

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,7 @@
 
   * Wrap initialize functions of integrations in try/catch statement.
   * Add logging of failed initializations.
-  * Add a `failedInitializations` array to prototype to capture names of any failed integrations to pass back to Segment api as part of event `_metadata`.
+  * Add a `failedInitializations` array to prototype to capture names of any failed integrations.
 
 3.1.0 / 2017-06-29
 ==================

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,10 @@
+3.1.1 / 2017-10-31
+==================
+
+  * Wrap initialize functions of integrations in try/catch statement.
+  * Add logging of failed initializations.
+  * Add a `failedInitializations` array to prototype to capture names of any failed integrations to pass back to Segment api as part of event `_metadata`.
+
 3.1.0 / 2017-06-29
 ==================
 

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -141,6 +141,9 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(settings, o
   }
 
   // initialize integrations, passing ready
+  // create a list of any integrations that did not initialize - this will be passed with all events for replay support:
+  // 
+  this.failedInitializations = [];
   each(function(integration) {
     if (options.initialPageview && integration.options.initialPageview === false) {
       integration.page = after(2, integration.page);
@@ -148,7 +151,12 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(settings, o
 
     integration.analytics = self;
     integration.once('ready', ready);
-    integration.initialize();
+    try {
+      integration.initialize();
+    } catch (e) {
+      self.failedInitializations.push(integration.prototype.name);
+      self.log('Error initializing %s integration: %o', integration.name, e);
+    }
   }, integrations);
 
   // backwards compat with angular plugin.

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -153,7 +153,7 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(settings, o
     try {
       integration.initialize();
     } catch (e) {
-      var integrationName = 'Unkown';
+      var integrationName = 'Unknown';
       if (integration.prototype && integration.prototype.name) {
         integrationName = integration.prototype.name;
       }

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -153,8 +153,12 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(settings, o
     try {
       integration.initialize();
     } catch (e) {
-      self.failedInitializations.push(integration.prototype.name);
-      self.log('Error initializing %s integration: %o', integration.name, e);
+      var integrationName = 'Unkown';
+      if (integration.prototype && integration.prototype.name) {
+        integrationName = integration.prototype.name;
+      }
+      self.failedInitializations.push(integrationName);
+      self.log('Error initializing %s integration: %o', integrationName, e);
     }
   }, integrations);
 

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -142,7 +142,6 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(settings, o
 
   // initialize integrations, passing ready
   // create a list of any integrations that did not initialize - this will be passed with all events for replay support:
-  // 
   this.failedInitializations = [];
   each(function(integration) {
     if (options.initialPageview && integration.options.initialPageview === false) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-core",
   "author": "Segment <friends@segment.com>",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "The hassle-free way to integrate analytics into any web application.",
   "keywords": [
     "analytics",

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -115,7 +115,7 @@ describe('Analytics', function() {
       Test.prototype.initialize = function() { throw new Error('Uh oh!'); };
       analytics.add(Test);
       analytics.initialize();
-      assert(analytics.initialized)
+      assert(analytics.initialized);
     });
 
     it('should store the names of integrations that did not initialize', function() {

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -126,6 +126,21 @@ describe('Analytics', function() {
       assert(analytics.failedInitializations[0] === Test.prototype.name);
     });
 
+    it('should handle cases where integration.initialize failes and integration.prototype is undefined', function() {
+      Test.initialize = function() { throw new Error('Uh oh!'); };
+      Test.prototype = undefined;
+      analytics.add(Test);
+      analytics.initialize();
+      assert(analytics.failedInitializations[0] === 'Unknown');
+    });
+
+    it('should handle cases where initialization fails and integration.prototype.name is undefined', function() {
+      Test.prototype.name = undefined;
+      analytics.add(Test);
+      analytics.initialize();
+      assert(analytics.failedInitializations[0] === 'Unknown');
+    });
+
     it('should not error without settings', function() {
       analytics.initialize();
     });

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -111,6 +111,21 @@ describe('Analytics', function() {
       group.load.restore();
     });
 
+    it('should gracefully handle integrations that fail to initialize', function() {
+      Test.prototype.initialize = function() { throw new Error('Uh oh!'); };
+      analytics.add(Test);
+      analytics.initialize();
+      assert(analytics.initialized)
+    });
+
+    it('should store the names of integrations that did not initialize', function() {
+      Test.prototype.initialize = function() { throw new Error('Uh oh!'); };
+      analytics.add(Test);
+      analytics.initialize();
+      assert(analytics.failedInitializations.length === 1);
+      assert(analytics.failedInitializations[0] === Test.prototype.name);
+    });
+
     it('should not error without settings', function() {
       analytics.initialize();
     });


### PR DESCRIPTION
PR changes the  handling of each integration's `.initialize` method to be run in a try/catch. This will ensure that if there are any bugs in the `.initialize` method of any given integration, it won't cause ajs to crash.

It also adds an array called `failedInitializations` to the prototype and stores the name of any failed integrations as a list. Next step will be to update the `analytics.js-segmentio-integration` to look for and pass this list back to our API in to be able to support replay.