### PR TITLE
Send disabled events to Segment.

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -295,8 +295,12 @@ Analytics.prototype.track = function(event, properties, options, fn) {
   plan = events[event];
   if (plan) {
     this.log('plan %o - %o', event, plan);
-    if (plan.enabled === false) return this._callback(fn);
-    defaults(msg.integrations, plan.integrations || {});
+    if (plan.enabled === false) {
+      // Disabled events should always be sent to Segment.
+      defaults(msg.integrations, { All: false, 'Segment.io': true });
+    } else {
+      defaults(msg.integrations, plan.integrations || {});
+    }
   }
 
   this._invoke('track', new Track(msg));

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -1080,14 +1080,16 @@ describe('Analytics', function() {
       assert.deepEqual(app, track.obj.context.app);
     });
 
-    it('should not call #_invoke if the event is disabled', function() {
+    it('should call #_invoke for Segment if the event is disabled', function() {
       analytics.options.plan = {
         track: {
           event: { enabled: false }
         }
       };
       analytics.track('event');
-      assert(!analytics._invoke.called);
+      assert(analytics._invoke.called);
+      var track = analytics._invoke.args[0][1];
+      assert.deepEqual({ All: false, 'Segment.io': true }, track.obj.integrations);
     });
 
     it('should call #_invoke if the event is enabled', function() {


### PR DESCRIPTION
Ref: https://paper.dropbox.com/doc/Sending-Disabled-Events-evdrvByT2cYUErnrbAUa3

Previously, the tracking plan/schema was applied by our client side libraries and it would filter disabled events on the client (i.e. it would never be sent to api.segment.io).

Moving forwards, the client side libraries will switch to sending disabled events ONLY to the Segment integration (and hence api.segment.io). This will enable us to surface disabled events in the debugger.