### PR TITLE
Add failed initializations lookup to invoke

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+3.1.2 / 2017-10-31
+==================
+
+  * Updates try/catch logic during initializations of integrations to look for integration.name - not integration.prototype.name
+  * Adds a check during analytics._invoke to check if the integration failed to initialize and if so, logs that it is passing and does not invoke it's corresponding method.
+
 3.1.1 / 2017-10-31
 ==================
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 ==================
 
   * Updates try/catch logic during initializations of integrations to look for integration.name - not integration.prototype.name
-  * Adds a check during analytics._invoke to check if the integration failed to initialize and if so, logs that it is passing and does not invoke it's corresponding method.
+  * Adds a check during `analytics._invoke` to check if the integration failed to initialize and if so, logs that it is passing and does not invoke it's corresponding method.
 
 3.1.1 / 2017-10-31
 ==================

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -592,9 +592,9 @@ Analytics.prototype._invoke = function(method, facade) {
   var self = this;
   this.emit('invoke', facade);
 
+  var failedInitializations = self.failedInitializations || [];
   each(function(integration, name) {
     if (!facade.enabled(name)) return;
-    var failedInitializations = self.failedInitializations || [];
     // Check if an integration failed to initialize.
     // If so, do not process the message as the integration is in an unstable state.
     if (failedInitializations.indexOf(name) >= 0) {

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -153,10 +153,7 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(settings, o
     try {
       integration.initialize();
     } catch (e) {
-      var integrationName = 'Unknown';
-      if (integration.prototype && integration.prototype.name) {
-        integrationName = integration.prototype.name;
-      }
+      var integrationName = integration.name;
       self.failedInitializations.push(integrationName);
       self.log('Error initializing %s integration: %o', integrationName, e);
     }
@@ -592,10 +589,18 @@ Analytics.prototype._callback = function(fn) {
  */
 
 Analytics.prototype._invoke = function(method, facade) {
+  var self = this;
   this.emit('invoke', facade);
 
   each(function(integration, name) {
     if (!facade.enabled(name)) return;
+    var failedInitializations = self.failedInitializations || [];
+    // Check if an integration failed to initialize.
+    // If so, do not process the message as the integration is in an unstable state.
+    if (failedInitializations.indexOf(name) >= 0) {
+      self.log('Skipping invokation of .%s method of %s integration. Integation failed to initialize properly.', method, name);
+      return;
+    }
     integration.invoke.call(integration, method, facade);
   }, this._integrations);
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-core",
   "author": "Segment <friends@segment.com>",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "The hassle-free way to integrate analytics into any web application.",
   "keywords": [
     "analytics",

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -120,25 +120,24 @@ describe('Analytics', function() {
 
     it('should store the names of integrations that did not initialize', function() {
       Test.prototype.initialize = function() { throw new Error('Uh oh!'); };
-      analytics.add(Test);
+      var test = new Test();
+      analytics.use(Test);
+      analytics.add(test);
       analytics.initialize();
       assert(analytics.failedInitializations.length === 1);
       assert(analytics.failedInitializations[0] === Test.prototype.name);
     });
 
-    it('should handle cases where integration.initialize failes and integration.prototype is undefined', function() {
-      Test.initialize = function() { throw new Error('Uh oh!'); };
-      Test.prototype = undefined;
-      analytics.add(Test);
+    it('should not process events for any integrations that failed to initialize', function() {
+      Test.prototype.initialize = function() { throw new Error('Uh oh!'); };
+      Test.prototype.page = sinon.spy();
+      var test = new Test();
+      test.invoke = sinon.spy();
+      analytics.use(Test);
+      analytics.add(test);
       analytics.initialize();
-      assert(analytics.failedInitializations[0] === 'Unknown');
-    });
-
-    it('should handle cases where initialization fails and integration.prototype.name is undefined', function() {
-      Test.prototype.name = undefined;
-      analytics.add(Test);
-      analytics.initialize();
-      assert(analytics.failedInitializations[0] === 'Unknown');
+      analytics.page('Test Page Event');
+      assert(test.invoke.notCalled);
     });
 
     it('should not error without settings', function() {


### PR DESCRIPTION
PR updates previous PR with a couple of key changes:

1. It does the lookup for the `name` of a given integration from `integration.name` not `integration.prototype.name`. This is actually where this property will be located at runtime.

2. It removes the fallback to `Unknown` if the integration's name fails to resolve. It's actually not possible for an integration instance to initialize without a `name` property. Therefore, having a fallback adds unnecessary confusion to the code. Also, if this somehow does happen, falling back on `undefined` is not going to break this functionality.

3. It adds a check to the `_invoke` method of the `Analytics` class that ensures we do not try and run an integration method if that integration has failed to initialize properly. It also logs this.