### PR TITLE
Revert "Send disabled events to Segment."

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -305,12 +305,8 @@ Analytics.prototype.track = function(event, properties, options, fn) {
   plan = events[event];
   if (plan) {
     this.log('plan %o - %o', event, plan);
-    if (plan.enabled === false) {
-      // Disabled events should always be sent to Segment.
-      defaults(msg.integrations, { All: false, 'Segment.io': true });
-    } else {
-      defaults(msg.integrations, plan.integrations || {});
-    }
+    if (plan.enabled === false) return this._callback(fn);
+    defaults(msg.integrations, plan.integrations || {});
   }
 
   this._invoke('track', new Track(msg));

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -1124,16 +1124,14 @@ describe('Analytics', function() {
       assert.deepEqual(app, track.obj.context.app);
     });
 
-    it('should call #_invoke for Segment if the event is disabled', function() {
+    it('should not call #_invoke if the event is disabled', function() {
       analytics.options.plan = {
         track: {
           event: { enabled: false }
         }
       };
       analytics.track('event');
-      assert(analytics._invoke.called);
-      var track = analytics._invoke.args[0][1];
-      assert.deepEqual({ All: false, 'Segment.io': true }, track.obj.integrations);
+      assert(!analytics._invoke.called);
     });
 
     it('should call #_invoke if the event is enabled', function() {


### PR DESCRIPTION
Reverts segmentio/analytics.js-core#43

Looks like build broke when it merged to master. Checking if the revert fixes it.