### PR TITLE
Tweak Karma CI options

### DIFF
--- a/karma.conf.ci.js
+++ b/karma.conf.ci.js
@@ -70,6 +70,10 @@ module.exports = function(config) {
 
     singleRun: true,
 
+    concurrency: 3,
+
+    retryLimit: 3,
+
     reporters: ['progress', 'junit'],
 
     browsers: ['PhantomJS'].concat(Object.keys(customLaunchers)),


### PR DESCRIPTION
* Limit SauceLabs concurrency on CI.
* Increase RetryLimit on CI.

I'm seeing lots of intermittent failures on CI. I ssh'd into a running build and tweaking the concurrency and retryLimit  options seemed the most reliable way to ensure builds don't fail due to sporadic failures.

I picked 3 as the concurrency as any higher made the tests fail more often. I increased the retryLimit to 3 as I do see browsers failing to start quite often (at least once every build), and retrying more than twice for such a common failure seemed like a good idea. We could go higher, but I didn't have tests fail even once with retrying thrice.

Limiting concurrency will make CI builds slower. I think this is ok because this repo isn't that frequently updated, and I think this'll save us in the long run by not having engineers waste time on fixing CI.