### PR TITLE
Tweak Karma CI config

### DIFF
--- a/karma.conf.ci.js
+++ b/karma.conf.ci.js
@@ -70,9 +70,9 @@ module.exports = function(config) {
 
     singleRun: true,
 
-    concurrency: 3,
+    concurrency: 2,
 
-    retryLimit: 3,
+    retryLimit: 5,
 
     reporters: ['progress', 'junit'],
 


### PR DESCRIPTION
Looks like the previous updates still have some sporadic failures. This lowers the concurrency even more and increases the retry limit in an attempt to reduce flaky test failures.