### PR TITLE
Add support for schema defaults.

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -311,6 +311,12 @@ Analytics.prototype.track = function(event, properties, options, fn) {
     } else {
       defaults(msg.integrations, plan.integrations || {});
     }
+  } else {
+    var defaultPlan = events.__default || { enabled: true };
+    if (!defaultPlan.enabled) {
+      // Disabled events should always be sent to Segment.
+      defaults(msg.integrations, { All: false, 'Segment.io': true });
+    }
   }
 
   this._invoke('track', new Track(msg));

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -1173,6 +1173,56 @@ describe('Analytics', function() {
       assert.deepEqual(msg.integrations(), { All: true, Segment: true });
     });
 
+    it('should call #_invoke if new events are enabled', function() {
+      analytics.options.plan = {
+        track: {
+          __default: { enabled: true }
+        }
+      };
+      analytics.track('event');
+      assert(analytics._invoke.called);
+      var track = analytics._invoke.args[0][1];
+      assert.deepEqual({}, track.obj.integrations);
+    });
+
+    it('should call #_invoke for Segment if new events are disabled', function() {
+      analytics.options.plan = {
+        track: {
+          __default: { enabled: false }
+        }
+      };
+      analytics.track('even');
+      assert(analytics._invoke.called);
+      var track = analytics._invoke.args[0][1];
+      assert.deepEqual({ All: false, 'Segment.io': true }, track.obj.integrations);
+    });
+
+    it('should use the event plan if it exists and ignore defaults', function() {
+      analytics.options.plan = {
+        track: {
+          event: { enabled: true },
+          __default: { enabled: false }
+        }
+      };
+      analytics.track('event');
+      assert(analytics._invoke.called);
+      var track = analytics._invoke.args[0][1];
+      assert.deepEqual({}, track.obj.integrations);
+    });
+
+    it('should merge the event plan if it exists and ignore defaults', function() {
+      analytics.options.plan = {
+        track: {
+          event: { enabled: true, integrations: { Mixpanel: false } },
+          __default: { enabled: false }
+        }
+      };
+      analytics.track('event');
+      assert(analytics._invoke.called);
+      var track = analytics._invoke.args[0][1];
+      assert.deepEqual({ Mixpanel: false }, track.obj.integrations);
+    });
+
     it('should not set ctx.integrations if plan.integrations is empty', function() {
       analytics.options.plan = { track: { event: {} } };
       analytics.track('event', {}, { campaign: {} });


### PR DESCRIPTION
If an event is not present in the tracking plan, we'll now lookup the schema defaults for the project.

If the event is disabled in the schema default, it will only be sent to the Segment integration (i.e. api.segment.io).

If the event is enabled in the schema default, it will be sent to all integrations as indicated in .integrations.

Ref: https://paper.dropbox.com/doc/Schema-Client-Side-Defaults-DufdS8Ej43mnFXvvMqm1b

Existing test cases cover the behaviour for when the schema defaults are not rendered.