### PR TITLE
Attach isFirstPageCall flag to page

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -140,7 +140,7 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(settings, o
   if (integrationCount <= 0) {
     ready();
   }
-
+  
   // initialize integrations, passing ready
   // create a list of any integrations that did not initialize - this will be passed with all events for replay support:
   this.failedInitializations = [];
@@ -152,7 +152,7 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(settings, o
     integration.analytics = self;
     integration.once('ready', ready);
     try {
-      integration.initialize(this._firstPageProps);
+      integration.initialize(self._firstPageProps);
     } catch (e) {
       var integrationName = integration.name;
       self.failedInitializations.push(integrationName);
@@ -161,7 +161,7 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(settings, o
       integration.ready();
     }
   }, integrations);
-
+  
   // backwards compat with angular plugin.
   // TODO: remove
   this.initialized = true;

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -152,7 +152,7 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(settings, o
     integration.analytics = self;
     integration.once('ready', ready);
     try {
-      integration.initialize(self._firstPageProps);
+      integration.initialize(self._firstPage);
     } catch (e) {
       var integrationName = integration.name;
       self.failedInitializations.push(integrationName);
@@ -465,7 +465,7 @@ Analytics.prototype.page = function(category, name, properties, options, fn) {
   });
   
   if (!this._pageCalledYet) {
-    this._firstPageProps = msg;
+    this._firstPage = msg;
     this._pageCalledYet = true;
   }
 

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -140,7 +140,7 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(settings, o
   if (integrationCount <= 0) {
     ready();
   }
-  
+
   // initialize integrations, passing ready
   // create a list of any integrations that did not initialize - this will be passed with all events for replay support:
   this.failedInitializations = [];

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -152,7 +152,7 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(settings, o
     integration.analytics = self;
     integration.once('ready', ready);
     try {
-      integration.initialize(self._firstPage);
+      integration.initialize();
     } catch (e) {
       var integrationName = integration.name;
       self.failedInitializations.push(integrationName);
@@ -463,13 +463,16 @@ Analytics.prototype.page = function(category, name, properties, options, fn) {
     options: options,
     name: name
   });
-  
-  if (!this._pageCalledYet) {
-    this._firstPage = msg;
+
+  var pageFacade = new Page(msg);
+  if (this._pageCalledYet) {
+    pageFacade.isFirstPageCall = false;
+  } else {
+    pageFacade.isFirstPageCall = true;
     this._pageCalledYet = true;
   }
 
-  this._invoke('page', new Page(msg));
+  this._invoke('page', pageFacade);
 
   this.emit('page', category, name, properties, options);
   this._callback(fn);

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -161,7 +161,7 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(settings, o
       integration.ready();
     }
   }, integrations);
-  
+
   // backwards compat with angular plugin.
   // TODO: remove
   this.initialized = true;

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -46,6 +46,7 @@ function Analytics() {
   this._integrations = {};
   this._readied = false;
   this._timeout = 300;
+  this._pageCalledYet = false;
   // XXX: BACKWARDS COMPATIBILITY
   this._user = user;
   this.log = debug('analytics.js');
@@ -151,7 +152,7 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(settings, o
     integration.analytics = self;
     integration.once('ready', ready);
     try {
-      integration.initialize();
+      integration.initialize(this._firstPageProps);
     } catch (e) {
       var integrationName = integration.name;
       self.failedInitializations.push(integrationName);
@@ -462,6 +463,11 @@ Analytics.prototype.page = function(category, name, properties, options, fn) {
     options: options,
     name: name
   });
+  
+  if (!this._pageCalledYet) {
+    this._firstPageProps = msg;
+    this._pageCalledYet = true;
+  }
 
   this._invoke('page', new Page(msg));
 

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -635,6 +635,15 @@ describe('Analytics', function() {
       });
       analytics.page('category', 'name', {}, {});
     });
+
+    it('should only attach an isFirstPageCall flag if its the first page call', function() {
+      analytics.page();
+      analytics.page();
+      var page = analytics._invoke.args[0][1];
+      var page2 = analytics._invoke.args[1][1];
+      assert(page.isFirstPageCall === true);
+      assert(page2.isFirstPageCall === false);
+    });
   });
 
   describe('#pageview', function() {


### PR DESCRIPTION
Integrations that `assumePageView` lose the first page call, including the data attached to the call. This attaches a flag to `page` indicating whether it's the first time it's been called so integrations can use custom logic on the first page call rather than dropping the call entirely.