### PR TITLE
Pass 'options' to trackLink() and trackForm()

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -335,10 +335,11 @@ Analytics.prototype.track = function(event, properties, options, fn) {
  * @param {Element|Array} links
  * @param {string|Function} event
  * @param {Object|Function} properties (optional)
+ * @param {Object|Function} options (optional)
  * @return {Analytics}
  */
 
-Analytics.prototype.trackClick = Analytics.prototype.trackLink = function(links, event, properties) {
+Analytics.prototype.trackClick = Analytics.prototype.trackLink = function(links, event, properties, options) {
   if (!links) return this;
   // always arrays, handles jquery
   if (type(links) === 'element') links = [links];
@@ -351,11 +352,12 @@ Analytics.prototype.trackClick = Analytics.prototype.trackLink = function(links,
     on(el, 'click', function(e) {
       var ev = is.fn(event) ? event(el) : event;
       var props = is.fn(properties) ? properties(el) : properties;
+      var opts = is.fn(options) ? options(el) : options;
       var href = el.getAttribute('href')
         || el.getAttributeNS('http://www.w3.org/1999/xlink', 'href')
         || el.getAttribute('xlink:href');
 
-      self.track(ev, props);
+      self.track(ev, props, opts);
 
       if (href && el.target !== '_blank' && !isMeta(e)) {
         prevent(e);
@@ -378,10 +380,11 @@ Analytics.prototype.trackClick = Analytics.prototype.trackLink = function(links,
  * @param {Element|Array} forms
  * @param {string|Function} event
  * @param {Object|Function} properties (optional)
+ * @param {Object|Function} options (optional)
  * @return {Analytics}
  */
 
-Analytics.prototype.trackSubmit = Analytics.prototype.trackForm = function(forms, event, properties) {
+Analytics.prototype.trackSubmit = Analytics.prototype.trackForm = function(forms, event, properties, options) {
   if (!forms) return this;
   // always arrays, handles jquery
   if (type(forms) === 'element') forms = [forms];
@@ -394,7 +397,8 @@ Analytics.prototype.trackSubmit = Analytics.prototype.trackForm = function(forms
 
       var ev = is.fn(event) ? event(el) : event;
       var props = is.fn(properties) ? properties(el) : properties;
-      self.track(ev, props);
+      var opts = is.fn(options) ? options(el) : options;
+      self.track(ev, props, opts);
 
       self._callback(function() {
         el.submit();

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -1301,6 +1301,12 @@ describe('Analytics', function() {
       assert(analytics.track.calledWith('event', { property: true }));
     });
 
+    it('should send an event, properties and options', function() {
+      analytics.trackLink(link, 'event', { property: true }, { option: true });
+      trigger(link, 'click');
+      assert(analytics.track.calledWith('event', { property: true }, { option: true }));
+    });
+
     it('should accept an event function', function() {
       function event(el) { return el.nodeName; }
       analytics.trackLink(link, event);
@@ -1308,11 +1314,19 @@ describe('Analytics', function() {
       assert(analytics.track.calledWith('A'));
     });
 
+
     it('should accept a properties function', function() {
       function properties(el) { return { type: el.nodeName }; }
       analytics.trackLink(link, 'event', properties);
       trigger(link, 'click');
       assert(analytics.track.calledWith('event', { type: 'A' }));
+    });
+
+    it('should accept a options function', function() {
+      function options(el) { return { type: el.nodeName }; }
+      analytics.trackLink(link, 'event', {}, options);
+      trigger(link, 'click');
+      assert(analytics.track.calledWith('event', {}, { type: 'A' }));
     });
 
     it('should load an href on click', function(done) {
@@ -1420,10 +1434,10 @@ describe('Analytics', function() {
       assert(!analytics.track.called);
     });
 
-    it('should send an event and properties', function() {
-      analytics.trackForm(form, 'event', { property: true });
+    it('should send an event, properties and options', function() {
+      analytics.trackForm(form, 'event', { property: true }, { option: true });
       submit.click();
-      assert(analytics.track.calledWith('event', { property: true }));
+      assert(analytics.track.calledWith('event', { property: true }, { option: true }));
     });
 
     it('should accept an event function', function() {
@@ -1438,6 +1452,13 @@ describe('Analytics', function() {
       analytics.trackForm(form, 'event', properties);
       submit.click();
       assert(analytics.track.calledWith('event', { property: true }));
+    });
+
+    it('should accept a options function', function() {
+      function options() { return { option: true }; }
+      analytics.trackForm(form, 'event', {}, options);
+      submit.click();
+      assert(analytics.track.calledWith('event', {}, { option: true }));
     });
 
     it('should call submit after a timeout', function(done) {


### PR DESCRIPTION
This PR adds the ability for users to pass in an 'options' object or function into trackLink() and trackForm() methods. It also includes updated test cases for this new functionality.