### PR TITLE
replaced ndhoule clone with lodash clone

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,8 @@
 
+3.2.6 / 2018-02-06
+==================
+
+  * Replace ndhoule clone with lodash clone to handle circular references in objects
 
 3.2.5 / 2017-11-09
 ==================

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -14,6 +14,7 @@ var Page = require('segmentio-facade').Page;
 var Track = require('segmentio-facade').Track;
 var after = require('@ndhoule/after');
 var bindAll = require('bind-all');
+var cloneDeep = require('lodash.clonedeep');
 var clone = require('@ndhoule/clone');
 var cookie = require('./cookie');
 var debug = require('debug');
@@ -117,7 +118,7 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(settings, o
   // add integrations
   each(function(opts, name) {
     var Integration = self.Integrations[name];
-    var integration = new Integration(clone(opts));
+    var integration = new Integration(cloneDeep(opts));
     self.log('initialize %o - %o', name, opts);
     self.add(integration);
   }, settings);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-core",
   "author": "Segment <friends@segment.com>",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "description": "The hassle-free way to integrate analytics into any web application.",
   "keywords": [
     "analytics",
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/segmentio/analytics.js-core#readme",
   "dependencies": {
+    "lodash.clonedeep": "4.5.0",    
     "@ndhoule/after": "^1.0.0",
     "@ndhoule/clone": "^1.0.0",
     "@ndhoule/defaults": "^2.0.1",


### PR DESCRIPTION
After the changes in
https://github.com/segmentio/analytics.js-private/pull/210
https://github.com/segmentio/snippet/pull/27
, the form that object representations of options can take will become much more dynamic due to their being directly passed in by the user. While testing, I found that objects containing circular references broke ndhoule clone as they caused a recursive overflow. Lodash's implementation handles this case and is generally better-maintained and tested so should replace the ndhoule version.