### PR TITLE
Switch from lodash clone to cloning via extend

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,9 @@
 
+3.2.6 / 2018-02-09
+==================
+
+  * Replace lodash deepclone with extend to lower ajs size
+
 3.2.6 / 2018-02-06
 ==================
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,8 @@
 
+3.2.6 / 2018-02-06
+==================
+
+  * Replace ndhoule clone with lodash clone to handle circular references in objects
 
 3.2.5 / 2017-11-09
 ==================

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -16,6 +16,7 @@ var after = require('@ndhoule/after');
 var bindAll = require('bind-all');
 var cloneDeep = require('lodash.clonedeep');
 var clone = require('@ndhoule/clone');
+var extend = require('extend');
 var cookie = require('./cookie');
 var debug = require('debug');
 var defaults = require('@ndhoule/defaults');
@@ -118,7 +119,9 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(settings, o
   // add integrations
   each(function(opts, name) {
     var Integration = self.Integrations[name];
-    var integration = new Integration(cloneDeep(opts));
+    var clonedOpts = {};
+    extend(true, cloned, opts); // deep clone opts
+    var integration = new Integration(clonedOpts);
     self.log('initialize %o - %o', name, opts);
     self.add(integration);
   }, settings);

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -14,6 +14,7 @@ var Page = require('segmentio-facade').Page;
 var Track = require('segmentio-facade').Track;
 var after = require('@ndhoule/after');
 var bindAll = require('bind-all');
+var cloneDeep = require('lodash.clonedeep');
 var clone = require('@ndhoule/clone');
 var cookie = require('./cookie');
 var debug = require('debug');
@@ -117,7 +118,7 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(settings, o
   // add integrations
   each(function(opts, name) {
     var Integration = self.Integrations[name];
-    var integration = new Integration(clone(opts));
+    var integration = new Integration(cloneDeep(opts));
     self.log('initialize %o - %o', name, opts);
     self.add(integration);
   }, settings);

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -14,7 +14,6 @@ var Page = require('segmentio-facade').Page;
 var Track = require('segmentio-facade').Track;
 var after = require('@ndhoule/after');
 var bindAll = require('bind-all');
-var cloneDeep = require('lodash.clonedeep');
 var clone = require('@ndhoule/clone');
 var extend = require('extend');
 var cookie = require('./cookie');
@@ -120,7 +119,7 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(settings, o
   each(function(opts, name) {
     var Integration = self.Integrations[name];
     var clonedOpts = {};
-    extend(true, cloned, opts); // deep clone opts
+    extend(true, clonedOpts, opts); // deep clone opts
     var integration = new Integration(clonedOpts);
     self.log('initialize %o - %o', name, opts);
     self.add(integration);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "homepage": "https://github.com/segmentio/analytics.js-core#readme",
   "dependencies": {
-    "lodash.clonedeep": "4.5.0",    
     "@ndhoule/after": "^1.0.0",
     "@ndhoule/clone": "^1.0.0",
     "@ndhoule/defaults": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-core",
   "author": "Segment <friends@segment.com>",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "description": "The hassle-free way to integrate analytics into any web application.",
   "keywords": [
     "analytics",
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/segmentio/analytics.js-core#readme",
   "dependencies": {
+    "lodash.clonedeep": "4.5.0",    
     "@ndhoule/after": "^1.0.0",
     "@ndhoule/clone": "^1.0.0",
     "@ndhoule/defaults": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-core",
   "author": "Segment <friends@segment.com>",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "description": "The hassle-free way to integrate analytics into any web application.",
   "keywords": [
     "analytics",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "homepage": "https://github.com/segmentio/analytics.js-core#readme",
   "dependencies": {
-    "lodash.clonedeep": "4.5.0",    
     "@ndhoule/after": "^1.0.0",
     "@ndhoule/clone": "^1.0.0",
     "@ndhoule/defaults": "^2.0.1",
@@ -42,6 +41,7 @@
     "@segment/store": "^1.3.20",
     "@segment/top-domain": "^3.0.0",
     "bind-all": "^1.0.0",
+    "extend": "3.0.1",
     "component-cookie": "^1.1.2",
     "component-emitter": "^1.2.1",
     "component-event": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "uuid": "^2.0.2"
   },
   "devDependencies": {
-    "@segment/analytics.js-integration": "^3.2.0",
+    "@segment/analytics.js-integration": "^3.2.1",
     "@segment/eslint-config": "^3.1.1",
     "browserify": "13.0.0",
     "compat-trigger-event": "^1.0.0",


### PR DESCRIPTION
Lodash clone is a massive dependency. `extend` is much smaller and still results in correct deep cloning with circular references.