### PR TITLE
Catch and guard against Integration errors

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -615,7 +615,11 @@ Analytics.prototype._invoke = function(method, facade) {
     if (failedInitializations.indexOf(name) >= 0) {
       self.log('Skipping invokation of .%s method of %s integration. Integation failed to initialize properly.', method, name);
     } else {
-      integration.invoke.call(integration, method, facade);
+      try {
+        integration.invoke.call(integration, method, facade);
+      } catch (e) {
+        self.log('Error invoking .%s method of %s integration: %o', method, name, e);
+      }
     }
   }, this._integrations);
 

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -322,6 +322,11 @@ describe('Analytics', function() {
       assert(!Test.prototype.invoke.called);
     });
 
+    it('should not crash when invoking integration fails', function() {
+      Test.prototype.invoke = function() { throw new Error('Uh oh!'); };
+      analytics.track('Test Event');
+    });
+
     it('should support .integrations to disable / select integrations', function() {
       var opts = { integrations: { Test: false } };
       analytics.identify('123', {}, opts);


### PR DESCRIPTION
To be able to record client side metrics, we need to modify analytics.js-integration to start propagate errors to analytics.js-core (https://paper.dropbox.com/doc/Analytics.js-Metrics-SDD-1hAD90lqGS4aZxHAHYPu7#:h2=analytics.js-integration) so that analytics.js-core can record metrics.

Currently analytics.js-integration is responsible for guarding when an integration method throws an error. Before changing the behaviour in analytics.js-integration, we need to make sure analytics.js-core guards against errors in integrations.