### PR TITLE
Fix flaky tests.

### DIFF
--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -1445,9 +1445,17 @@ describe('Analytics', function() {
       analytics.trackForm(form);
       submit.click();
       setTimeout(function() {
+        // This test has a tendency to fail on IE. We retry upto 5 times in a
+        // loop.
+        for (var i = 0; i < 5; i++) {
+          if (spy.called === true) {
+            return done();
+          }
+        }
+        // Run a final assertion.
         assert(spy.called);
         done();
-      }, 50);
+      }, 1000);
     });
 
     it('should trigger an existing submit handler', function(done) {

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -23,6 +23,16 @@ describe('cookie', function() {
 
     it('should get an existing cookie', function() {
       cookie.set('x', { a: 'b' });
+      // This test has a tendency to fail on IE. We retry upto 5 times in a
+      // loop.
+      for (var i = 0; i < 5; i++) {
+        var x = cookie.get('x');
+        if (x === { a: 'b' }) {
+          return;
+        }
+      }
+      // Run a final assertion. Using assert here so we can print a helpful
+      // error message.
       assert.deepEqual(cookie.get('x'), { a: 'b' });
     });
 
@@ -35,6 +45,16 @@ describe('cookie', function() {
   describe('#set', function() {
     it('should set a cookie', function() {
       cookie.set('x', { a: 'b' });
+      // This test has a tendency to fail on IE. We retry upto 5 times in a
+      // loop.
+      for (var i = 0; i < 5; i++) {
+        var x = cookie.get('x');
+        if (x === { a: 'b' }) {
+          return;
+        }
+      }
+      // Run a final assertion. Using assert here so we can print a helpful
+      // error message.
       assert.deepEqual(cookie.get('x'), { a: 'b' });
     });
   });


### PR DESCRIPTION
There are a few flaky tests here https://cloudup.com/cs68SLifvsj.

* Analytics #trackForm should call submit after a timeout
* cookie #set/#get should set a cookie

These seem to fail on IE mostly. Instead of suppressing these tests, we are going to be more lenient and retry these tests.
