### PR TITLE
Add support for disabling integrations at runtime

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -118,8 +118,13 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(settings, o
   // add integrations
   each(function(opts, name) {
     // Don't load disabled integrations
-    if (options.integrations && options.integrations[name] === false) {
-      return;
+    if (options.integrations) {
+      if (
+        options.integrations[name] === false
+        || options.integrations.All === false && !options.integrations[name]
+      ) {
+        return;
+      }
     }
 
     var Integration = self.Integrations[name];

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -232,7 +232,7 @@ Analytics.prototype.identify = function(id, traits, options, fn) {
     userId: user.id()
   });
 
-  // Add the disabled integrations so that the server-side ones are disabled too
+  // Add the initialize integrations so the server-side ones can be disabled too
   if (this.options.integrations) {
     defaults(msg.integrations, this.options.integrations);
   }
@@ -284,7 +284,7 @@ Analytics.prototype.group = function(id, traits, options, fn) {
     groupId: group.id()
   });
 
-  // Add the disabled integrations so that the server-side ones are disabled too
+  // Add the initialize integrations so the server-side ones can be disabled too
   if (this.options.integrations) {
     defaults(msg.integrations, this.options.integrations);
   }
@@ -343,7 +343,7 @@ Analytics.prototype.track = function(event, properties, options, fn) {
     }
   }
 
-  // Add the disabled integrations so that the server-side ones are disabled too
+  // Add the initialize integrations so the server-side ones can be disabled too
   defaults(msg.integrations, this._mergeInitializeAndPlanIntegrations(planIntegrationOptions));
 
   this._invoke('track', new Track(msg));
@@ -490,7 +490,7 @@ Analytics.prototype.page = function(category, name, properties, options, fn) {
     name: name
   });
 
-  // Add the disabled integrations so that the server-side ones are disabled too
+  // Add the initialize integrations so the server-side ones can be disabled too
   if (this.options.integrations) {
     defaults(msg.integrations, this.options.integrations);
   }
@@ -541,7 +541,7 @@ Analytics.prototype.alias = function(to, from, options, fn) {
     userId: to
   });
 
-  // Add the disabled integrations so that the server-side ones are disabled too
+  // Add the initialize integrations so the server-side ones can be disabled too
   if (this.options.integrations) {
     defaults(msg.integrations, this.options.integrations);
   }

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -118,7 +118,7 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(settings, o
   // add integrations
   each(function(opts, name) {
     // Don't load disabled integrations
-    if (options.disabledIntegrations && options.disabledIntegrations.indexOf(name) !== -1) {
+    if (options.integrations && options.integrations[name] === false) {
       return;
     }
 
@@ -710,14 +710,9 @@ Analytics.prototype.normalize = function(msg) {
   msg.context.page = defaults(msg.context.page || {}, pageDefaults());
 
   // Add the disabled integrations so that the server-side ones are disabled too
-  var disabledIntegrations = this.options.disabledIntegrations;
-  if (disabledIntegrations) {
-    for (var i = 0; i < disabledIntegrations.length; i++) {
-      var integrationName = disabledIntegrations[i];
-      if (msg.integrations[integrationName] == null) {
-        msg.integrations[integrationName] = false;
-      }
-    }
+  var integrations = this.options.integrations;
+  if (integrations) {
+    msg.integrations = defaults(msg.integrations, integrations);
   }
 
   return msg;

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -227,6 +227,11 @@ Analytics.prototype.identify = function(id, traits, options, fn) {
     userId: user.id()
   });
 
+  // Add the disabled integrations so that the server-side ones are disabled too
+  if (this.options.integrations) {
+    defaults(msg.integrations, this.options.integrations);
+  }
+
   this._invoke('identify', new Identify(msg));
 
   // emit
@@ -274,6 +279,11 @@ Analytics.prototype.group = function(id, traits, options, fn) {
     groupId: group.id()
   });
 
+  // Add the disabled integrations so that the server-side ones are disabled too
+  if (this.options.integrations) {
+    defaults(msg.integrations, this.options.integrations);
+  }
+
   this._invoke('group', new Group(msg));
 
   this.emit('group', id, traits, options);
@@ -301,6 +311,7 @@ Analytics.prototype.track = function(event, properties, options, fn) {
   // figure out if the event is archived.
   var plan = this.options.plan || {};
   var events = plan.track || {};
+  var planIntegrationOptions = {};
 
   // normalize
   var msg = this.normalize({
@@ -315,17 +326,20 @@ Analytics.prototype.track = function(event, properties, options, fn) {
     this.log('plan %o - %o', event, plan);
     if (plan.enabled === false) {
       // Disabled events should always be sent to Segment.
-      defaults(msg.integrations, { All: false, 'Segment.io': true });
+      planIntegrationOptions = { All: false, 'Segment.io': true };
     } else {
-      defaults(msg.integrations, plan.integrations || {});
+      planIntegrationOptions = plan.integrations || {};
     }
   } else {
     var defaultPlan = events.__default || { enabled: true };
     if (!defaultPlan.enabled) {
       // Disabled events should always be sent to Segment.
-      defaults(msg.integrations, { All: false, 'Segment.io': true });
+      planIntegrationOptions = { All: false, 'Segment.io': true };
     }
   }
+
+  // Add the disabled integrations so that the server-side ones are disabled too
+  defaults(msg.integrations, this._mergeInitializeAndPlanIntegrations(planIntegrationOptions));
 
   this._invoke('track', new Track(msg));
 
@@ -471,6 +485,11 @@ Analytics.prototype.page = function(category, name, properties, options, fn) {
     name: name
   });
 
+  // Add the disabled integrations so that the server-side ones are disabled too
+  if (this.options.integrations) {
+    defaults(msg.integrations, this.options.integrations);
+  }
+
   this._invoke('page', new Page(msg));
 
   this.emit('page', category, name, properties, options);
@@ -516,6 +535,11 @@ Analytics.prototype.alias = function(to, from, options, fn) {
     previousId: from,
     userId: to
   });
+
+  // Add the disabled integrations so that the server-side ones are disabled too
+  if (this.options.integrations) {
+    defaults(msg.integrations, this.options.integrations);
+  }
 
   this._invoke('alias', new Alias(msg));
 
@@ -709,13 +733,45 @@ Analytics.prototype.normalize = function(msg) {
   // Ensure all outgoing requests include page data in their contexts.
   msg.context.page = defaults(msg.context.page || {}, pageDefaults());
 
-  // Add the disabled integrations so that the server-side ones are disabled too
-  var integrations = this.options.integrations;
-  if (integrations) {
-    msg.integrations = defaults(msg.integrations, integrations);
+  return msg;
+};
+
+/**
+ * Merges the tracking plan and initialization integration options.
+ *
+ * @param  {Object} planIntegrations Tracking plan integrations.
+ * @return {Object}                  The merged integrations.
+ */
+Analytics.prototype._mergeInitializeAndPlanIntegrations = function(planIntegrations) {
+  // Do nothing if there are no initialization integrations
+  if (!this.options.integrations) {
+    return planIntegrations;
   }
 
-  return msg;
+  // Clone the initialization integrations
+  var integrations = extend({}, this.options.integrations);
+  var integrationName;
+
+  // Allow the tracking plan to disable integrations that were explicitly
+  // enabled on initialization
+  if (planIntegrations.All === false) {
+    for (integrationName in integrations) {
+      if (integrations.hasOwnProperty(integrationName)) {
+        delete integrations[integrationName];
+      }
+    }
+  }
+
+  for (integrationName in planIntegrations) {
+    if (planIntegrations.hasOwnProperty(integrationName)) {
+      // Don't allow the tracking plan to re-enable disabled integrations
+      if (this.options.integrations[integrationName] !== false) {
+        integrations[integrationName] = planIntegrations[integrationName];
+      }
+    }
+  }
+
+  return integrations;
 };
 
 /**

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -764,11 +764,7 @@ Analytics.prototype._mergeInitializeAndPlanIntegrations = function(planIntegrati
   // Allow the tracking plan to disable integrations that were explicitly
   // enabled on initialization
   if (planIntegrations.All === false) {
-    for (integrationName in integrations) {
-      if (integrations.hasOwnProperty(integrationName)) {
-        delete integrations[integrationName];
-      }
-    }
+    integrations = {};
   }
 
   for (integrationName in planIntegrations) {

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -117,6 +117,11 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(settings, o
 
   // add integrations
   each(function(opts, name) {
+    // Don't load disabled integrations
+    if (options.disabledIntegrations && options.disabledIntegrations.indexOf(name) !== -1) {
+      return;
+    }
+
     var Integration = self.Integrations[name];
     var clonedOpts = {};
     extend(true, clonedOpts, opts); // deep clone opts
@@ -703,6 +708,17 @@ Analytics.prototype.normalize = function(msg) {
 
   // Ensure all outgoing requests include page data in their contexts.
   msg.context.page = defaults(msg.context.page || {}, pageDefaults());
+
+  // Add the disabled integrations so that the server-side ones are disabled too
+  var disabledIntegrations = this.options.disabledIntegrations;
+  if (disabledIntegrations) {
+    for (var i = 0; i < disabledIntegrations.length; i++) {
+      var integrationName = disabledIntegrations[i];
+      if (msg.integrations[integrationName] == null) {
+        msg.integrations[integrationName] = false;
+      }
+    }
+  }
 
   return msg;
 };

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -1239,17 +1239,17 @@ describe('Analytics', function() {
       analytics.initialize(settings, {
         integrations: {
           Test: true
-        }
-      });
-      analytics.options.plan = {
-        track: {
-          event1: { enabled: false },
-          event2: {
-            enabled: true,
-            integrations: { Test: false }
+        },
+        plan: {
+          track: {
+            event1: { enabled: false },
+            event2: {
+              enabled: true,
+              integrations: { Test: false }
+            }
           }
         }
-      };
+      });
 
       analytics.track('event1', { prop: true });
       var track = analytics._invoke.args[0][1];
@@ -1264,17 +1264,17 @@ describe('Analytics', function() {
       analytics.initialize(settings, {
         integrations: {
           Test: false
-        }
-      });
-      analytics.options.plan = {
-        track: {
-          event1: { enabled: true },
-          event2: {
-            enabled: true,
-            integrations: { Test: true }
+        },
+        plan: {
+          track: {
+            event1: { enabled: true },
+            event2: {
+              enabled: true,
+              integrations: { Test: true }
+            }
           }
         }
-      };
+      });
 
       analytics.track('event1', { prop: true });
       var track1 = analytics._invoke.args[0][1];

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -245,6 +245,35 @@ describe('Analytics', function() {
       });
     });
 
+    it('should not load any integrations when integrations.All === false', function(done) {
+      Test.readyOnInitialize();
+      analytics.addIntegration(Test);
+      analytics.ready(function() {
+        assert(!analytics._integrations.Test);
+        done();
+      });
+      analytics.initialize(settings, {
+        integrations: {
+          All: false
+        }
+      });
+    });
+
+    it('should load explicitly enabled integrations when integrations.All === false', function(done) {
+      Test.readyOnInitialize();
+      analytics.addIntegration(Test);
+      analytics.ready(function() {
+        assert(analytics._integrations.Test);
+        done();
+      });
+      analytics.initialize(settings, {
+        integrations: {
+          All: false,
+          Test: {}
+        }
+      });
+    });
+
     it('should send settings to an integration', function(done) {
       Test = function(options) {
         assert.deepEqual(settings.Test, options);

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -1235,6 +1235,56 @@ describe('Analytics', function() {
       assert.deepEqual(track.obj.integrations, { Test: true });
     });
 
+    it('should allow tracking plan to disable integrations explicitly enabled via initialize .integrations option', function() {
+      analytics.initialize(settings, {
+        integrations: {
+          Test: true
+        }
+      });
+      analytics.options.plan = {
+        track: {
+          event1: { enabled: false },
+          event2: {
+            enabled: true,
+            integrations: { Test: false }
+          }
+        }
+      };
+
+      analytics.track('event1', { prop: true });
+      var track = analytics._invoke.args[0][1];
+      assert.deepEqual(track.obj.integrations, { All: false, 'Segment.io': true });
+
+      analytics.track('event2', { prop: true });
+      var track2 = analytics._invoke.args[1][1];
+      assert.deepEqual(track2.obj.integrations, { Test: false });
+    });
+
+    it('should prevent tracking plan from enabling integrations disabled via initialize .integrations option', function() {
+      analytics.initialize(settings, {
+        integrations: {
+          Test: false
+        }
+      });
+      analytics.options.plan = {
+        track: {
+          event1: { enabled: true },
+          event2: {
+            enabled: true,
+            integrations: { Test: true }
+          }
+        }
+      };
+
+      analytics.track('event1', { prop: true });
+      var track1 = analytics._invoke.args[0][1];
+      assert.deepEqual(track1.obj.integrations, { Test: false });
+
+      analytics.track('event2', { prop: true });
+      var track2 = analytics._invoke.args[1][1];
+      assert.deepEqual(track2.obj.integrations, { Test: false });
+    });
+
     it('should accept top level option .context', function() {
       var app = { name: 'segment' };
       analytics.track('event', { prop: true }, { context: { app: app } });

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -231,6 +231,20 @@ describe('Analytics', function() {
       analytics.initialize(settings);
     });
 
+    it('should not load disabled integrations', function(done) {
+      Test.readyOnInitialize();
+      analytics.addIntegration(Test);
+      analytics.ready(function() {
+        assert(!analytics._integrations.Test);
+        done();
+      });
+      analytics.initialize(settings, {
+        integrations: {
+          Test: false
+        }
+      });
+    });
+
     it('should send settings to an integration', function(done) {
       Test = function(options) {
         assert.deepEqual(settings.Test, options);
@@ -597,6 +611,32 @@ describe('Analytics', function() {
       assert.deepEqual(page.options('AdRoll'), { opt: true });
     });
 
+    it('should use the initialize .integrations option', function() {
+      analytics.initialize(settings, {
+        integrations: {
+          Test: false
+        }
+      });
+      analytics.page({ prop: true });
+      var page = analytics._invoke.args[0][1];
+      assert.deepEqual(page.obj.integrations, { Test: false });
+    });
+
+    it('should be able to override the initialize .integrations option', function() {
+      analytics.initialize(settings, {
+        integrations: {
+          Test: false
+        }
+      });
+      analytics.page({ prop: true }, {
+        integrations: {
+          Test: true
+        }
+      });
+      var page = analytics._invoke.args[0][1];
+      assert.deepEqual(page.obj.integrations, { Test: true });
+    });
+
     it('should accept top level option .context', function() {
       var app = { name: 'segment' };
       analytics.page({ prop: true }, { context: { app: app } });
@@ -825,6 +865,32 @@ describe('Analytics', function() {
       assert.deepEqual({ opt: true }, identify.options('AdRoll'));
     });
 
+    it('should use the initialize .integrations option', function() {
+      analytics.initialize(settings, {
+        integrations: {
+          Test: false
+        }
+      });
+      analytics.identify(1, { trait: true });
+      var identify = analytics._invoke.args[0][1];
+      assert.deepEqual(identify.obj.integrations, { Test: false });
+    });
+
+    it('should be able to override the initialize .integrations option', function() {
+      analytics.initialize(settings, {
+        integrations: {
+          Test: false
+        }
+      });
+      analytics.identify(1, { trait: true }, {
+        integrations: {
+          Test: true
+        }
+      });
+      var identify = analytics._invoke.args[0][1];
+      assert.deepEqual(identify.obj.integrations, { Test: true });
+    });
+
     it('should accept top level option .context', function() {
       analytics.identify(1, { trait: true }, { context: { app: { name: 'segment' } } });
       var identify = analytics._invoke.args[0][1];
@@ -1004,6 +1070,32 @@ describe('Analytics', function() {
       assert.deepEqual(group.options('AdRoll'), { opt: true });
     });
 
+    it('should use the initialize .integrations option', function() {
+      analytics.initialize(settings, {
+        integrations: {
+          Test: false
+        }
+      });
+      analytics.group(1, { trait: true });
+      var group = analytics._invoke.args[0][1];
+      assert.deepEqual(group.obj.integrations, { Test: false });
+    });
+
+    it('should be able to override the initialize .integrations option', function() {
+      analytics.initialize(settings, {
+        integrations: {
+          Test: false
+        }
+      });
+      analytics.group(1, { trait: true }, {
+        integrations: {
+          Test: true
+        }
+      });
+      var group = analytics._invoke.args[0][1];
+      assert.deepEqual(group.obj.integrations, { Test: true });
+    });
+
     it('should accept top level option .context', function() {
       var app = { name: 'segment' };
       analytics.group(1, { trait: true }, { context: { app: app } });
@@ -1115,6 +1207,32 @@ describe('Analytics', function() {
       analytics.track('event', { prop: true }, { integrations: { AdRoll: { opt: true } } });
       var track = analytics._invoke.args[0][1];
       assert.deepEqual({ opt: true }, track.options('AdRoll'));
+    });
+
+    it('should use the initialize .integrations option', function() {
+      analytics.initialize(settings, {
+        integrations: {
+          Test: false
+        }
+      });
+      analytics.track('event', { prop: true });
+      var track = analytics._invoke.args[0][1];
+      assert.deepEqual(track.obj.integrations, { Test: false });
+    });
+
+    it('should be able to override the initialize .integrations option', function() {
+      analytics.initialize(settings, {
+        integrations: {
+          Test: false
+        }
+      });
+      analytics.track('event', { prop: true }, {
+        integrations: {
+          Test: true
+        }
+      });
+      var track = analytics._invoke.args[0][1];
+      assert.deepEqual(track.obj.integrations, { Test: true });
     });
 
     it('should accept top level option .context', function() {
@@ -1549,6 +1667,38 @@ describe('Analytics', function() {
         done();
       });
       analytics.alias('new', 'old', { opt: true });
+    });
+
+    it('should accept top level option .integrations', function() {
+      analytics.alias('new', 'old', { integrations: { AdRoll: { opt: true } } });
+      var alias = analytics._invoke.args[0][1];
+      assert.deepEqual({ opt: true }, alias.options('AdRoll'));
+    });
+
+    it('should use the initialize .integrations option', function() {
+      analytics.initialize(settings, {
+        integrations: {
+          Test: false
+        }
+      });
+      analytics.alias('new', 'old');
+      var alias = analytics._invoke.args[0][1];
+      assert.deepEqual(alias.obj.integrations, { Test: false });
+    });
+
+    it('should be able to override the initialize .integrations option', function() {
+      analytics.initialize(settings, {
+        integrations: {
+          Test: false
+        }
+      });
+      analytics.alias('new', 'old', {
+        integrations: {
+          Test: true
+        }
+      });
+      var alias = analytics._invoke.args[0][1];
+      assert.deepEqual(alias.obj.integrations, { Test: true });
     });
   });
 


### PR DESCRIPTION
Adds an `integrations` option to `analytics.initialize()` that behaves exactly like the [page/identify/track/group/alias method's `integrations` option](https://segment.com/docs/sources/website/analytics.js/#selecting-destinations). It prevents any disabled device mode integrations from loading/initializing and automatically sets the `integrations` option on the page/identify/track/group/alias methods so that cloud mode integrations can be disabled too.

This is useful for disabling/enabling integrations at runtime based on user tracking consent (Do Not Track, GDPR, etc).

cc @segmentio/destinations-team @segmentio/cx-eng 