### PR TITLE
Add Metrics

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -17,6 +17,7 @@ var bindAll = require('bind-all');
 var clone = require('@ndhoule/clone');
 var extend = require('extend');
 var cookie = require('./cookie');
+var metrics = require('./metrics');
 var debug = require('debug');
 var defaults = require('@ndhoule/defaults');
 var each = require('@ndhoule/each');
@@ -154,9 +155,17 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(settings, o
     integration.analytics = self;
     integration.once('ready', ready);
     try {
+      metrics.increment('analytics_js.integration.invoke', {
+        method: 'initialize',
+        integration_name: integration.name
+      });
       integration.initialize();
     } catch (e) {
       var integrationName = integration.name;
+      metrics.increment('analytics_js.integration.invoke.error', {
+        method: 'initialize',
+        integration_name: integration.name
+      });
       self.failedInitializations.push(integrationName);
       self.log('Error initializing %s integration: %o', integrationName, e);
       // Mark integration as ready to prevent blocking of anyone listening to analytics.ready()
@@ -573,6 +582,7 @@ Analytics.prototype._options = function(options) {
   options = options || {};
   this.options = options;
   cookie.options(options.cookie);
+  metrics.options(options.metrics);
   store.options(options.localStorage);
   user.options(options.user);
   group.options(options.group);
@@ -605,6 +615,9 @@ Analytics.prototype._callback = function(fn) {
 
 Analytics.prototype._invoke = function(method, facade) {
   var self = this;
+  metrics.increment('analytics_js.invoke', {
+    method: method
+  });
   this.emit('invoke', facade);
 
   var failedInitializations = self.failedInitializations || [];
@@ -616,8 +629,16 @@ Analytics.prototype._invoke = function(method, facade) {
       self.log('Skipping invokation of .%s method of %s integration. Integation failed to initialize properly.', method, name);
     } else {
       try {
+        metrics.increment('analytics_js.integration.invoke', {
+          method: method,
+          integration_name: integration.name
+        });
         integration.invoke.call(integration, method, facade);
       } catch (e) {
+        metrics.increment('analytics_js.integration.invoke.error', {
+          method: method,
+          integration_name: integration.name
+        });
         self.log('Error invoking .%s method of %s integration: %o', method, name, e);
       }
     }
@@ -728,3 +749,4 @@ module.exports = Analytics;
 module.exports.cookie = cookie;
 module.exports.memory = memory;
 module.exports.store = store;
+module.exports.metrics = metrics;

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -1,0 +1,97 @@
+'use strict';
+
+var bindAll = require('bind-all');
+var send = require('@segment/send-json');
+var debug = require('debug')('analytics.js:metrics');
+
+function Metrics(options) {
+  this.options(options);
+}
+
+/**
+ * Set the metrics options.
+ *
+ * @param {Object} options
+ *   @field {String} host
+ *   @field {Number} sampleRate
+ *   @field {Number} flushTimer
+ */
+
+Metrics.prototype.options = function(options) {
+  options = options || {};
+
+  this.host = options.host || 'api.segment.io/v1';
+  this.sampleRate = options.sampleRate || 0; // disable metrics by default.
+  this.flushTimer = options.flushTimer || 30 * 1000 /* 30s */;
+  this.maxQueueSize = options.maxQueueSize || 20;
+
+  this.queue = [];
+
+  if (this.sampleRate > 0) {
+    var self = this;
+    setInterval(function() {
+      self._flush();
+    }, this.flushTimer);
+  }
+};
+
+/**
+ * Increments the counter identified by name and tags by one.
+ *
+ * @param {String} metric Name of the metric to increment.
+ * @param {Object} tags Dimensions associated with the metric.
+ */
+Metrics.prototype.increment = function(metric, tags) {
+  if (Math.random() > this.sampleRate) {
+    return;
+  }
+
+  if (this.queue.length >= this.maxQueueSize) {
+    return;
+  }
+
+  this.queue.push({ type: 'counter', metric: metric, tags: tags });
+
+  // Trigger a flush if this is an error metric.
+  if (metric.indexOf('error') > 0) {
+    this._flush();
+  }
+};
+
+/**
+ * Flush all queued metrics.
+ */
+Metrics.prototype._flush = function() {
+  var self = this;
+
+  if (self.queue.length <= 0) {
+    return;
+  }
+
+  var payload = { metrics: this.queue };
+  var headers = { 'Content-Type': 'text/plain' };
+
+  self.queue = [];
+
+  // This endpoint does not support jsonp, so only proceed if the browser
+  // supports xhr.
+  if (send.type !== 'xhr') return;
+
+  send('https://' + this.host + '/m', payload, headers, function(err, res) {
+    debug('sent %O, received %O', payload, [err, res]);
+  });
+};
+
+
+/**
+ * Expose the metrics singleton.
+ */
+
+module.exports = bindAll(new Metrics());
+
+
+/**
+ * Expose the `Metrics` constructor.
+ */
+
+module.exports.Metrics = Metrics;

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "new-date": "^1.0.0",
     "next-tick": "^0.2.2",
     "segmentio-facade": "^3.0.2",
-    "uuid": "^2.0.2"
+    "uuid": "^2.0.2",
+    "@segment/send-json": "^3.0.0"
   },
   "devDependencies": {
     "@segment/analytics.js-integration": "^3.2.1",

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -19,6 +19,7 @@ var cookie = Analytics.cookie;
 var group = analytics.group();
 var store = Analytics.store;
 var user = analytics.user();
+var metrics = Analytics.metrics;
 
 describe('Analytics', function() {
   var analytics;
@@ -104,11 +105,13 @@ describe('Analytics', function() {
     beforeEach(function() {
       sinon.spy(user, 'load');
       sinon.spy(group, 'load');
+      sinon.spy(metrics, 'increment');
     });
 
     afterEach(function() {
       user.load.restore();
       group.load.restore();
+      metrics.increment.restore();
     });
 
     it('should gracefully handle integrations that fail to initialize', function() {
@@ -155,6 +158,25 @@ describe('Analytics', function() {
       analytics.initialize();
     });
 
+    it('should record a metric for integration errors', function() {
+      Test.prototype.initialize = function() { throw new Error('Uh oh!'); };
+      var test = new Test();
+      analytics.use(Test);
+      analytics.add(test);
+      analytics.initialize();
+      assert(analytics.initialized);
+
+      sinon.assert.calledTwice(metrics.increment);
+      sinon.assert.calledWith(metrics.increment, 'analytics_js.integration.invoke', {
+        method: 'initialize',
+        integration_name: 'Test'
+      });
+      sinon.assert.calledWith(metrics.increment, 'analytics_js.integration.invoke.error', {
+        method: 'initialize',
+        integration_name: 'Test'
+      });
+    });
+
     it('should not error without settings', function() {
       analytics.initialize();
     });
@@ -196,6 +218,19 @@ describe('Analytics', function() {
       analytics.addIntegration(Test);
       analytics.ready(done);
       analytics.initialize(settings);
+    });
+
+    it('should listen on integration ready events', function(done) {
+      Test.readyOnInitialize();
+      analytics.addIntegration(Test);
+      analytics.ready(done);
+      analytics.initialize(settings);
+
+      sinon.assert.calledOnce(metrics.increment);
+      sinon.assert.calledWith(metrics.increment, 'analytics_js.integration.invoke', {
+        method: 'initialize',
+        integration_name: 'Test'
+      });
     });
 
     it('should still call ready with unknown integrations', function(done) {
@@ -297,6 +332,12 @@ describe('Analytics', function() {
       analytics.addIntegration(Test);
       analytics.ready(done);
       analytics.initialize(settings);
+
+      sinon.spy(metrics, 'increment');
+    });
+
+    afterEach(function() {
+      metrics.increment.restore();
     });
 
     it('should invoke a method on integration with facade', function() {
@@ -327,6 +368,37 @@ describe('Analytics', function() {
       analytics.track('Test Event');
     });
 
+    it('should record a metric when invoking an integration', function() {
+      analytics.track('Test Event');
+
+      sinon.assert.calledTwice(metrics.increment);
+      sinon.assert.calledWith(metrics.increment, 'analytics_js.invoke', {
+        method: 'track'
+      });
+      sinon.assert.calledWith(metrics.increment, 'analytics_js.integration.invoke', {
+        method: 'track',
+        integration_name: 'Test'
+      });
+    });
+
+    it('should record a metric when invoking an integration', function() {
+      Test.prototype.invoke = function() { throw new Error('Uh oh!'); };
+      analytics.identify('prateek');
+
+      sinon.assert.calledThrice(metrics.increment);
+      sinon.assert.calledWith(metrics.increment, 'analytics_js.invoke', {
+        method: 'identify'
+      });
+      sinon.assert.calledWith(metrics.increment, 'analytics_js.integration.invoke', {
+        method: 'identify',
+        integration_name: 'Test'
+      });
+      sinon.assert.calledWith(metrics.increment, 'analytics_js.integration.invoke.error', {
+        method: 'identify',
+        integration_name: 'Test'
+      });
+    });
+
     it('should support .integrations to disable / select integrations', function() {
       var opts = { integrations: { Test: false } };
       analytics.identify('123', {}, opts);
@@ -351,6 +423,7 @@ describe('Analytics', function() {
       sinon.stub(store, 'options');
       sinon.stub(user, 'options');
       sinon.stub(group, 'options');
+      sinon.stub(metrics, 'options');
     });
 
     afterEach(function() {
@@ -358,11 +431,17 @@ describe('Analytics', function() {
       store.options.restore();
       user.options.restore();
       group.options.restore();
+      metrics.options.restore();
     });
 
     it('should set cookie options', function() {
       analytics._options({ cookie: { option: true } });
       assert(cookie.options.calledWith({ option: true }));
+    });
+
+    it('should set metrics options', function() {
+      analytics._options({ metrics: { option: true } });
+      assert(metrics.options.calledWith({ option: true }));
     });
 
     it('should set store options', function() {

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -1,0 +1,189 @@
+'use strict';
+
+var assert = require('proclaim');
+var metrics = require('../lib').constructor.metrics;
+var sinon = require('sinon');
+var send = require('@segment/send-json');
+
+describe('metrics', function() {
+  var xhr;
+  var spy;
+
+  beforeEach(function() {
+    xhr = sinon.useFakeXMLHttpRequest();
+
+    spy = sinon.spy();
+    xhr.onCreate = spy;
+  });
+
+  afterEach(function() {
+    metrics.options({});
+
+    if (xhr.restore) xhr.restore();
+  });
+
+  describe('#increment', function() {
+    it('should not enqueue items by default', function() {
+      metrics.increment('test', []);
+
+      assert.deepEqual(metrics.queue, []);
+    });
+
+    it('should enqueue items when sampleRate is set', function() {
+      metrics.options({ sampleRate : 1 });
+
+      metrics.increment('test', []);
+
+      assert.deepEqual(metrics.queue, [ { type: 'counter', metric: 'test', tags: [] } ]);
+    });
+  });
+
+  describe('#_flush', function() {
+    beforeEach(function() {
+      metrics.options({ sampleRate: 1 });
+    });
+
+    it('should not make a request if queue is empty', function() {
+      metrics._flush();
+
+      sinon.assert.notCalled(spy);
+    });
+
+    it('should make a request if queue has an item and supports xhr', function() {
+      if (send.type !== 'xhr') return;
+
+      metrics.increment('foo', {});
+
+      metrics._flush();
+
+      sinon.assert.calledOnce(spy);
+      var req = spy.getCall(0).args[0];
+      assert.strictEqual(req.url, 'https://api.segment.io/v1/m');
+      assert.strictEqual(req.requestBody, '{"metrics":[{"type":"counter","metric":"foo","tags":{}}]}');
+    });
+
+    it('should make a request if queue has multiple items and supports xhr', function() {
+      if (send.type !== 'xhr') return;
+
+      metrics.increment('test1', { foo: 'bar' });
+      metrics.increment('test2', {});
+
+      metrics._flush();
+
+      sinon.assert.calledOnce(spy);
+      var req = spy.getCall(0).args[0];
+      assert.strictEqual(req.url, 'https://api.segment.io/v1/m');
+      assert.strictEqual(req.requestBody, '{"metrics":[{"type":"counter","metric":"test1","tags":{"foo":"bar"}},{"type":"counter","metric":"test2","tags":{}}]}');
+    });
+
+    it('should not make a request if queue has an item and does not support xhr', function() {
+      if (send.type === 'xhr') return;
+
+      metrics.increment('foo', {});
+
+      metrics._flush();
+
+      sinon.assert.notCalled(spy);
+    });
+
+    it('should not make a request if queue has multiple items and does not support xhr', function() {
+      if (send.type === 'xhr') return;
+
+      metrics.increment('test1', { foo: 'bar' });
+      metrics.increment('test2', {});
+
+      metrics._flush();
+
+      sinon.assert.notCalled(spy);
+    });
+
+    it('should empty the queue', function() {
+      metrics.increment('test1', { foo: 'bar' });
+
+      metrics._flush();
+
+      assert.deepEqual(metrics.queue, []);
+    });
+
+    it('should respect the default maxQueueSize', function() {
+      for (var i = 0; i < 30; i++) {
+        metrics.increment('test');
+      }
+
+      assert.deepEqual(metrics.queue.length, 20);
+    });
+
+    it('should respect a custom maxQueueSize', function() {
+      metrics.options({ sampleRate: 1, maxQueueSize: 1000 });
+
+      for (var i = 0; i < 2000; i++) {
+        metrics.increment('test');
+      }
+
+      assert.deepEqual(metrics.queue.length, 1000);
+    });
+  });
+
+  describe('flush timer', function() {
+    beforeEach(function() {
+      metrics.options({
+        sampleRate: 1,
+        flushTimer: 1
+      });
+    });
+
+    it('should flush', function(done) {
+      if (send.type !== 'xhr') return done();
+
+      metrics.increment('test1', { foo: 'bar' });
+
+      setTimeout(function() {
+        sinon.assert.calledOnce(spy);
+        var req = spy.getCall(0).args[0];
+        assert.strictEqual(req.url, 'https://api.segment.io/v1/m');
+        assert.strictEqual(req.requestBody, '{"metrics":[{"type":"counter","metric":"test1","tags":{"foo":"bar"}}]}');
+
+        assert.deepEqual(metrics.queue, []);
+
+        done();
+      }, 10);
+    });
+  });
+
+  describe('#options', function() {
+    it('should handle empty options correctly', function() {
+      metrics.options({});
+
+      assert.equal(metrics.host, 'api.segment.io/v1');
+      assert.equal(metrics.sampleRate, 0);
+      assert.equal(metrics.flushTimer, 30000);
+      assert.equal(metrics.maxQueueSize, 20);
+
+      assert.deepEqual(metrics.queue, []);
+    });
+
+    it('should respect host option', function() {
+      metrics.options({ host: 'api.segment.com/v1' });
+
+      assert.equal(metrics.host, 'api.segment.com/v1');
+    });
+
+    it('should respect sampleRate option', function() {
+      metrics.options({ sampleRate: 0.1 });
+
+      assert.equal(metrics.sampleRate, 0.1);
+    });
+
+    it('should respect flushTimer option', function() {
+      metrics.options({ flushTimer: 10 * 1000 });
+
+      assert.equal(metrics.flushTimer, 10000);
+    });
+
+    it('should respect maxQueueSize option', function() {
+      metrics.options({ maxQueueSize: 30 });
+
+      assert.equal(metrics.maxQueueSize, 30);
+    });
+  });
+});


### PR DESCRIPTION
Ref: https://paper.dropbox.com/doc/Analytics.js-Metrics-SDD-1hAD90lqGS4aZxHAHYPu7

This makes two main changes:
* Add a metrics client for analytics.js to report metrics to
* Integrate metrics client into analytics.js to report key metrics

The metrics client buffers metrics in memory and periodically uploads them to a server. By default, the metrics client does not upload any metrics (though it points to api.segment.io). It also automatically flushes the buffer when an error metric is recorded. Lastly - the client supports sampling so we can control the metrics being reported.

Metrics are invoked for the following operations:
* A metric is recorded for each method invoked in analytics.js.
* A metric is recorded for each attempt to invoke an analytics.js integration.
* A metric is recorded for each failed attempt when invoking an analytics.js integration.