### PR TITLE
Fix Metrics Client Payload

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -68,7 +68,7 @@ Metrics.prototype._flush = function() {
     return;
   }
 
-  var payload = { metrics: this.queue };
+  var payload = { series: this.queue };
   var headers = { 'Content-Type': 'text/plain' };
 
   self.queue = [];

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -59,7 +59,7 @@ describe('metrics', function() {
       sinon.assert.calledOnce(spy);
       var req = spy.getCall(0).args[0];
       assert.strictEqual(req.url, 'https://api.segment.io/v1/m');
-      assert.strictEqual(req.requestBody, '{"metrics":[{"type":"counter","metric":"foo","tags":{}}]}');
+      assert.strictEqual(req.requestBody, '{"series":[{"type":"counter","metric":"foo","tags":{}}]}');
     });
 
     it('should make a request if queue has multiple items and supports xhr', function() {
@@ -73,7 +73,7 @@ describe('metrics', function() {
       sinon.assert.calledOnce(spy);
       var req = spy.getCall(0).args[0];
       assert.strictEqual(req.url, 'https://api.segment.io/v1/m');
-      assert.strictEqual(req.requestBody, '{"metrics":[{"type":"counter","metric":"test1","tags":{"foo":"bar"}},{"type":"counter","metric":"test2","tags":{}}]}');
+      assert.strictEqual(req.requestBody, '{"series":[{"type":"counter","metric":"test1","tags":{"foo":"bar"}},{"type":"counter","metric":"test2","tags":{}}]}');
     });
 
     it('should not make a request if queue has an item and does not support xhr', function() {
@@ -141,7 +141,7 @@ describe('metrics', function() {
         sinon.assert.calledOnce(spy);
         var req = spy.getCall(0).args[0];
         assert.strictEqual(req.url, 'https://api.segment.io/v1/m');
-        assert.strictEqual(req.requestBody, '{"metrics":[{"type":"counter","metric":"test1","tags":{"foo":"bar"}}]}');
+        assert.strictEqual(req.requestBody, '{"series":[{"type":"counter","metric":"test1","tags":{"foo":"bar"}}]}');
 
         assert.deepEqual(metrics.queue, []);
 


### PR DESCRIPTION
The client was incorrectly sending data as `metrics` instead of `series`. This was a bug in the SDD itself (fixed now).