### PR TITLE
Fix metrics payload

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -50,7 +50,7 @@ Metrics.prototype.increment = function(metric, tags) {
     return;
   }
 
-  this.queue.push({ type: 'counter', metric: metric, tags: tags });
+  this.queue.push({ type: 'Counter', metric: metric, value: 1, tags: tags });
 
   // Trigger a flush if this is an error metric.
   if (metric.indexOf('error') > 0) {

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -34,7 +34,7 @@ describe('metrics', function() {
 
       metrics.increment('test', []);
 
-      assert.deepEqual(metrics.queue, [ { type: 'counter', metric: 'test', tags: [] } ]);
+      assert.deepEqual(metrics.queue, [ { type: 'Counter', metric: 'test', value: 1, tags: [] } ]);
     });
   });
 
@@ -59,7 +59,7 @@ describe('metrics', function() {
       sinon.assert.calledOnce(spy);
       var req = spy.getCall(0).args[0];
       assert.strictEqual(req.url, 'https://api.segment.io/v1/m');
-      assert.strictEqual(req.requestBody, '{"series":[{"type":"counter","metric":"foo","tags":{}}]}');
+      assert.strictEqual(req.requestBody, '{"series":[{"type":"Counter","metric":"foo","value":1,"tags":{}}]}');
     });
 
     it('should make a request if queue has multiple items and supports xhr', function() {
@@ -73,7 +73,7 @@ describe('metrics', function() {
       sinon.assert.calledOnce(spy);
       var req = spy.getCall(0).args[0];
       assert.strictEqual(req.url, 'https://api.segment.io/v1/m');
-      assert.strictEqual(req.requestBody, '{"series":[{"type":"counter","metric":"test1","tags":{"foo":"bar"}},{"type":"counter","metric":"test2","tags":{}}]}');
+      assert.strictEqual(req.requestBody, '{"series":[{"type":"Counter","metric":"test1","value":1,"tags":{"foo":"bar"}},{"type":"Counter","metric":"test2","value":1,"tags":{}}]}');
     });
 
     it('should not make a request if queue has an item and does not support xhr', function() {
@@ -141,7 +141,7 @@ describe('metrics', function() {
         sinon.assert.calledOnce(spy);
         var req = spy.getCall(0).args[0];
         assert.strictEqual(req.url, 'https://api.segment.io/v1/m');
-        assert.strictEqual(req.requestBody, '{"series":[{"type":"counter","metric":"test1","tags":{"foo":"bar"}}]}');
+        assert.strictEqual(req.requestBody, '{"series":[{"type":"Counter","metric":"test1","value":1,"tags":{"foo":"bar"}}]}');
 
         assert.deepEqual(metrics.queue, []);
 


### PR DESCRIPTION
Discovered some more bugs during testing, two fixes here are:

1. type (i.e. Counter) is sent in titlecase, not lowercase.
2. Value must be sent. Since we only support incrementing by 1 on the client for now, this value is always 1.