### PR TITLE
Fix the tracking plan when load options are specified

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -785,7 +785,7 @@ Analytics.prototype._mergeInitializeAndPlanIntegrations = function(planIntegrati
   // Allow the tracking plan to disable integrations that were explicitly
   // enabled on initialization
   if (planIntegrations.All === false) {
-    integrations = {};
+    integrations = { All: false };
   }
 
   for (integrationName in planIntegrations) {

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -1351,6 +1351,7 @@ describe('Analytics', function() {
     it('should allow tracking plan to disable integrations explicitly enabled via initialize .integrations option', function() {
       analytics.initialize(settings, {
         integrations: {
+          All: false,
           Test: true
         },
         plan: {
@@ -1370,7 +1371,7 @@ describe('Analytics', function() {
 
       analytics.track('event2', { prop: true });
       var track2 = analytics._invoke.args[1][1];
-      assert.deepEqual(track2.obj.integrations, { Test: false });
+      assert.deepEqual(track2.obj.integrations, { All: false, Test: false });
     });
 
     it('should prevent tracking plan from enabling integrations disabled via initialize .integrations option', function() {


### PR DESCRIPTION
The tracking plan `All: false` is being stripped when `All: false` is passed in the load options, which makes the tracking plan mostly inert.