### PR TITLE
Ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coverage
 node_modules
+package-lock.json


### PR DESCRIPTION
We currently don't check this in, and it's annoying to have to have to manually delete this when running locally.