### PR TITLE
Split install into it's own step.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run: npm config set "//registry.npmjs.org/:_authToken" $NPM_AUTH
+      - run: make install
       - run: make test
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}


### PR DESCRIPTION
Seperate the commands for two reasons:
* see their output seperately
* time them seperately so we can better understand where the bottlenecks are (though 99.999% sure it's saucelabs :P)