### PR TITLE
add logging for cookie test

### DIFF
--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -34,7 +34,9 @@ describe('cookie', function() {
 
   describe('#set', function() {
     it('should set a cookie', function() {
+      console.log('setting cookie. document.cookie is', document.cookie);
       cookie.set('x', { a: 'b' });
+      console.log('cookie set. document.cookie is', document.cookie);
       assert.deepEqual(cookie.get('x'), { a: 'b' });
     });
   });

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -8,6 +8,10 @@ describe('cookie', function() {
     // Just to make sure that
     // URIError is never thrown here.
     document.cookie = 'bad=%';
+
+    // enable debugging for cookie package so we can better
+    // observe flaky tests on IE/Edge.
+    window.localStorage.setItem('debug', 'cookie');
   });
 
   afterEach(function() {
@@ -34,6 +38,7 @@ describe('cookie', function() {
 
   describe('#set', function() {
     it('should set a cookie', function() {
+      // Logging so we can better observe flaky tests on IE/Edge.
       console.log('setting cookie. document.cookie is', document.cookie);
       cookie.set('x', { a: 'b' });
       console.log('cookie set. document.cookie is', document.cookie);


### PR DESCRIPTION
this test flakes quite often. I haven't been able to reproduce at all locally even with saucelabs, so I'm adding logging to the test so that when it fails on CI, we have better visibility into what went wrong.