### PR TITLE
Clear cookies before each cookie test

### DIFF
--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -4,7 +4,7 @@ var assert = require('proclaim');
 var cookie = require('../lib').constructor.cookie;
 
 describe('cookie', function() {
-  before(function() {
+  beforeEach(function() {
     // Just to make sure that
     // URIError is never thrown here.
     document.cookie = 'bad=%';


### PR DESCRIPTION
A cookie test is randomly failing on Circle CI. It only happens on `Edge_17_17134_0_(Windows_10_0_0)`.

I can only reproduce it on SauceLabs (Circle CI or local), it works perfectly in a local VM with same versions and minimal configuration.

Failures on Circle CI : [#417](https://circleci.com/gh/segmentio/analytics.js-core/417), [#416](https://circleci.com/gh/segmentio/analytics.js-core/416), [#415](https://circleci.com/gh/segmentio/analytics.js-core/415)
> cookie #set should set a cookie - Edge_17_17134_0_(Windows_10_0_0).@segment/analytics.js-core.cookie
> ```js
> AssertionError: null deepEqual { a: 'b' }
> ```

---

Resetting `document.cookie` using `beforeEach` instead of `before` seems to fix the issue.
I ran 15+ successful test iterations after this PR, while I was getting ~1 failure out of 3 before.

Ref LIB-354