### PR TITLE
Publish only on version tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,18 +18,22 @@ jobs:
     docker:
       - image: circleci/node:4-browsers
     steps:
+      - checkout
       - attach_workspace: { at: . }
       - run: npm publish .
 workflows:
   version: 2
   test_and_publish:
     jobs:
-      - test
-      - publish:
+      - test:
+          filters:
+            tags:
+              only: /.*/
+      - deploy:
           requires:
             - test
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)*(-.+)?/
             branches:
-              only: master
+              ignore: /.*/


### PR DESCRIPTION
The previous configuration would run the publish step if the tag matched a version tag, OR if the branch was `master`.

ideally we would run this only if there was a version tag AND the branch was `master`, but this should work for now.