### PR TITLE
Improve CI reporting

### DIFF
--- a/karma.conf.ci.js
+++ b/karma.conf.ci.js
@@ -74,7 +74,11 @@ module.exports = function(config) {
 
     retryLimit: 5,
 
-    reporters: ['summary', 'junit'],
+    reporters: ['spec', 'summary', 'junit'],
+
+    specReporter: {
+      suppressPassed: true
+    },
 
     browsers: ['PhantomJS'].concat(Object.keys(customLaunchers)),
 


### PR DESCRIPTION
The summary reporter doesn't show any details about test failures.

This adds back the  spec reporter but configures it to suppress output about failed tests.