### PR TITLE
LIB-868: Update entity.js to support localStorage

### DIFF
--- a/lib/entity.js
+++ b/lib/entity.js
@@ -106,10 +106,45 @@ Entity.prototype.id = function(id) {
  */
 
 Entity.prototype._getId = function() {
-  var ret = this._options.persist
-    ? this.storage().get(this._options.cookie.key)
-    : this._id;
-  return ret === undefined ? null : ret;
+  if (!this._options.persist) {
+    return this._id === undefined ? null : this._id;
+  }
+
+  // Check cookies.
+  var cookieId = this._getIdFromCookie();
+  if (cookieId) {
+    return cookieId;
+  }
+
+  // Check localStorage.
+  var lsId = this._getIdFromLocalStorage();
+  if (lsId) {
+    // Copy the id to cookies so we can read it directly from cookies next time.
+    this._setIdInCookies(lsId);
+    return lsId;
+  }
+
+  return null;
+};
+
+/**
+ * Get the entity's id from cookies.
+ *
+ * @return {String}
+ */
+
+Entity.prototype._getIdFromCookie = function() {
+  return this.storage().get(this._options.cookie.key);
+};
+
+/**
+ * Get the entity's id from cookies.
+ *
+ * @return {String}
+ */
+
+Entity.prototype._getIdFromLocalStorage = function() {
+  return store.get(this._options.cookie.key);
 };
 
 /**
@@ -120,10 +155,31 @@ Entity.prototype._getId = function() {
 
 Entity.prototype._setId = function(id) {
   if (this._options.persist) {
-    this.storage().set(this._options.cookie.key, id);
+    this._setIdInCookies(id);
+    this._setIdInLocalStorage(id);
   } else {
     this._id = id;
   }
+};
+
+/**
+ * Set the entity's `id` in cookies.
+ *
+ * @param {String} id
+ */
+
+Entity.prototype._setIdInCookies = function(id) {
+  this.storage().set(this._options.cookie.key, id);
+};
+
+/**
+ * Set the entity's `id` in local storage.
+ *
+ * @param {String} id
+ */
+
+Entity.prototype._setIdInLocalStorage = function(id) {
+  store.set(this._options.cookie.key, id);
 };
 
 /**
@@ -201,8 +257,8 @@ Entity.prototype.identify = function(id, traits) {
 
 Entity.prototype.save = function() {
   if (!this._options.persist) return false;
-  cookie.set(this._options.cookie.key, this.id());
-  store.set(this._options.localStorage.key, this.traits());
+  this._setId(this.id());
+  this._setTraits(this.traits());
   return true;
 };
 
@@ -213,7 +269,8 @@ Entity.prototype.save = function() {
 Entity.prototype.logout = function() {
   this.id(null);
   this.traits({});
-  cookie.remove(this._options.cookie.key);
+  this.storage().remove(this._options.cookie.key);
+  store.remove(this._options.cookie.key);
   store.remove(this._options.localStorage.key);
 };
 
@@ -231,6 +288,6 @@ Entity.prototype.reset = function() {
  */
 
 Entity.prototype.load = function() {
-  this.id(cookie.get(this._options.cookie.key));
-  this.traits(store.get(this._options.localStorage.key));
+  this.id(this.id());
+  this.traits(this.traits());
 };

--- a/test/group.test.js
+++ b/test/group.test.js
@@ -39,6 +39,24 @@ describe('group', function() {
       assert(group.id() === 'gid');
       assert(group.traits().trait === true);
     });
+
+    it('id() should fallback to localStorage', function() {
+      var group = new Group();
+
+      group.id('gid');
+
+      // delete the cookie.
+      cookie.remove(cookieKey);
+
+      // verify cookie is deleted.
+      assert.equal(cookie.get(cookieKey), null);
+
+      // verify id() returns the id even when cookie is deleted.
+      assert.equal(group.id(), 'gid');
+
+      // verify cookie value is retored from localStorage.
+      assert.equal(cookie.get(cookieKey), 'gid');
+    });
   });
 
   describe('#id', function() {
@@ -226,6 +244,12 @@ describe('group', function() {
       assert(cookie.get(cookieKey) === 'id');
     });
 
+    it('should save an id to localStorage', function() {
+      group.id('id');
+      group.save();
+      assert(store.get(cookieKey) === 'id');
+    });
+
     it('should save properties to local storage', function() {
       group.properties({ property: true });
       group.save();
@@ -249,14 +273,21 @@ describe('group', function() {
       assert.deepEqual(group.properties(), {});
     });
 
-    it('should clear a cookie', function() {
+    it('should clear id in cookie', function() {
       group.id('id');
       group.save();
       group.logout();
       assert(cookie.get(cookieKey) === null);
     });
 
-    it('should clear local storage', function() {
+    it('should clear id in localStorage', function() {
+      group.id('id');
+      group.save();
+      group.logout();
+      assert(store.get(cookieKey) === undefined);
+    });
+
+    it('should clear traits in local storage', function() {
       group.properties({ property: true });
       group.save();
       group.logout();

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -43,6 +43,24 @@ describe('user', function() {
       assert(user.traits().trait === true);
     });
 
+    it('id() should fallback to localStorage', function() {
+      var user = new User();
+
+      user.id('id');
+
+      // delete the cookie.
+      cookie.remove(cookieKey);
+
+      // verify cookie is deleted.
+      assert.equal(cookie.get(cookieKey), null);
+
+      // verify id() returns the id even when cookie is deleted.
+      assert.equal(user.id(), 'id');
+
+      // verify cookie value is retored from localStorage.
+      assert.equal(cookie.get(cookieKey), 'id');
+    });
+
     it('should pick the old "_sio" anonymousId', function() {
       rawCookie('_sio', 'anonymous-id----user-id');
       var user = new User();
@@ -400,6 +418,12 @@ describe('user', function() {
       assert(cookie.get(cookieKey) === 'id');
     });
 
+    it('should save an id to localStorage', function() {
+      user.id('id');
+      user.save();
+      assert.equal(store.get(cookieKey), 'id');
+    });
+
     it('should save traits to local storage', function() {
       user.traits({ trait: true });
       user.save();
@@ -425,14 +449,21 @@ describe('user', function() {
       assert(user.traits(), {});
     });
 
-    it('should clear a cookie', function() {
+    it('should clear id in cookie', function() {
       user.id('id');
       user.save();
       user.logout();
       assert(cookie.get(cookieKey) === null);
     });
 
-    it('should clear local storage', function() {
+    it('should clear id in local storage', function() {
+      user.id('id');
+      user.save();
+      user.logout();
+      assert(store.get(cookieKey) === undefined);
+    });
+
+    it('should clear traits in local storage', function() {
       user.traits({ trait: true });
       user.save();
       user.logout();


### PR DESCRIPTION
This changes entity.js to dual  write ids to localStorage and the cookies.

Reads will check the cookie first, and fallback to the localStorage when a cookie is not available. When cookies are not available during reads, and localStorage is, we write the value to the cookie as well.