### PR TITLE
Generate MessageId

### DIFF
--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -10,6 +10,9 @@ var each = require('@ndhoule/each');
 var includes = require('@ndhoule/includes');
 var map = require('@ndhoule/map');
 var type = require('component-type');
+var uuid = require('uuid').v4;
+var json = require('json3');
+var md5 = require('spark-md5').hash;
 
 /**
  * HOP.
@@ -74,6 +77,9 @@ function normalize(msg, list) {
       context[key] = opts[key];
     }
   }, opts);
+
+  // generate and attach a messageId to msg
+  msg.messageId = 'ajs-' + md5(json.stringify(msg) + uuid());
 
   // cleanup
   delete msg.options;

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "install": "^0.7.3",
     "is": "^3.1.0",
     "json3": "^3.3.2",
+    "spark-md5": "^2.0.2",
     "new-date": "^1.0.0",
     "next-tick": "^0.2.2",
     "segmentio-facade": "^3.0.2",

--- a/test/normalize.test.js
+++ b/test/normalize.test.js
@@ -17,7 +17,12 @@ describe('normalize', function() {
     it('should merge original with normalized', function() {
       msg.userId = 'user-id';
       opts.integrations = { Segment: true };
-      assert.deepEqual(normalize(msg, list), {
+      var normalized = normalize(msg, list);
+
+      assert.lengthEquals(normalized.messageId, 36);
+      delete normalized.messageId;
+
+      assert.deepEqual(normalized, {
         integrations: { Segment: true },
         userId: 'user-id',
         context: {}
@@ -44,7 +49,12 @@ describe('normalize', function() {
       opts.campaign = { name: 'campaign-name' };
       opts.library = 'analytics-wordpress';
       opts.traits = { trait: true };
-      assert.deepEqual(normalize(msg, list), {
+      var normalized = normalize(msg, list);
+
+      assert.lengthEquals(normalized.messageId, 36);
+      delete normalized.messageId;
+
+      assert.deepEqual(normalized, {
         integrations: {},
         context: {
           campaign: { name: 'campaign-name' },
@@ -61,7 +71,12 @@ describe('normalize', function() {
       it('should move to .integrations', function() {
         opts.Segment = true;
         opts.KISSmetrics = false;
-        assert.deepEqual(normalize(msg, list), {
+        var normalized = normalize(msg, list);
+
+        assert.lengthEquals(normalized.messageId, 36);
+        delete normalized.messageId;
+
+        assert.deepEqual(normalized, {
           context: {},
           integrations: {
             Segment: true,
@@ -73,7 +88,12 @@ describe('normalize', function() {
       it('should match integration names', function() {
         opts.segment = true;
         opts.KissMetrics = false;
-        assert.deepEqual(normalize(msg, list), {
+        var normalized = normalize(msg, list);
+
+        assert.lengthEquals(normalized.messageId, 36);
+        delete normalized.messageId;
+
+        assert.deepEqual(normalized, {
           context: {},
           integrations: {
             segment: true,
@@ -84,7 +104,12 @@ describe('normalize', function() {
 
       it('should move .All', function() {
         opts.All = true;
-        assert.deepEqual(normalize(msg, list), {
+        var normalized = normalize(msg, list);
+
+        assert.lengthEquals(normalized.messageId, 36);
+        delete normalized.messageId;
+
+        assert.deepEqual(normalized, {
           context: {},
           integrations: {
             All: true
@@ -94,7 +119,12 @@ describe('normalize', function() {
 
       it('should move .all', function() {
         opts.all = true;
-        assert.deepEqual(normalize(msg, list), {
+        var normalized = normalize(msg, list);
+
+        assert.lengthEquals(normalized.messageId, 36);
+        delete normalized.messageId;
+
+        assert.deepEqual(normalized, {
           context: {},
           integrations: {
             all: true
@@ -108,7 +138,12 @@ describe('normalize', function() {
         opts.integrations = {};
         opts.integrations.all = true;
         opts.integrations.Segment = true;
-        assert.deepEqual(normalize(msg, list), {
+        var normalized = normalize(msg, list);
+
+        assert.lengthEquals(normalized.messageId, 36);
+        delete normalized.messageId;
+
+        assert.deepEqual(normalized, {
           context: {},
           integrations: {
             all: true,
@@ -128,7 +163,12 @@ describe('normalize', function() {
       it('should move to .integrations', function() {
         providers.Segment = true;
         providers.KISSmetrics = false;
-        assert.deepEqual(normalize(msg, list), {
+        var normalized = normalize(msg, list);
+
+        assert.lengthEquals(normalized.messageId, 36);
+        delete normalized.messageId;
+
+        assert.deepEqual(normalized, {
           context: {},
           integrations: {
             Segment: true,
@@ -140,7 +180,12 @@ describe('normalize', function() {
       it('should match integration names', function() {
         providers.segment = true;
         providers.KissMetrics = false;
-        assert.deepEqual(normalize(msg, list), {
+        var normalized = normalize(msg, list);
+
+        assert.lengthEquals(normalized.messageId, 36);
+        delete normalized.messageId;
+
+        assert.deepEqual(normalized, {
           context: {},
           integrations: {
             segment: true,
@@ -151,7 +196,12 @@ describe('normalize', function() {
 
       it('should move .All', function() {
         providers.All = true;
-        assert.deepEqual(normalize(msg, list), {
+        var normalized = normalize(msg, list);
+
+        assert.lengthEquals(normalized.messageId, 36);
+        delete normalized.messageId;
+
+        assert.deepEqual(normalized, {
           context: {},
           integrations: {
             All: true
@@ -161,7 +211,12 @@ describe('normalize', function() {
 
       it('should move .all', function() {
         providers.all = true;
-        assert.deepEqual(normalize(msg, list), {
+        var normalized = normalize(msg, list);
+
+        assert.lengthEquals(normalized.messageId, 36);
+        delete normalized.messageId;
+
+        assert.deepEqual(normalized, {
           context: {},
           integrations: {
             all: true
@@ -175,7 +230,12 @@ describe('normalize', function() {
         opts.integrations = {};
         opts.integrations.all = true;
         opts.integrations.Segment = true;
-        assert.deepEqual(normalize(msg, list), {
+        var normalized = normalize(msg, list);
+
+        assert.lengthEquals(normalized.messageId, 36);
+        delete normalized.messageId;
+
+        assert.deepEqual(normalized, {
           context: {},
           integrations: {
             all: true,
@@ -187,7 +247,12 @@ describe('normalize', function() {
       it('should override if providers[key] is an object', function() {
         providers.Segment = {};
         opts.integrations = { Segment: true };
-        assert.deepEqual(normalize(msg, list), {
+        var normalized = normalize(msg, list);
+
+        assert.lengthEquals(normalized.messageId, 36);
+        delete normalized.messageId;
+
+        assert.deepEqual(normalized, {
           context: {},
           integrations: {
             Segment: {}
@@ -206,7 +271,12 @@ describe('normalize', function() {
       it('should move to .integrations', function() {
         providers.Segment = true;
         opts.KISSmetrics = false;
-        assert.deepEqual(normalize(msg, list), {
+        var normalized = normalize(msg, list);
+
+        assert.lengthEquals(normalized.messageId, 36);
+        delete normalized.messageId;
+
+        assert.deepEqual(normalized, {
           context: {},
           integrations: {
             Segment: true,
@@ -218,7 +288,12 @@ describe('normalize', function() {
       it('should prefer options object', function() {
         providers.Segment = { option: true };
         opts.Segment = true;
-        assert.deepEqual(normalize(msg, list), {
+        var normalized = normalize(msg, list);
+
+        assert.lengthEquals(normalized.messageId, 36);
+        delete normalized.messageId;
+
+        assert.deepEqual(normalized, {
           context: {},
           integrations: {
             Segment: { option: true }
@@ -226,5 +301,14 @@ describe('normalize', function() {
         });
       });
     });
+  });
+  it('should properly randomize .messageId', function() {
+    var set = {};
+    var count = 1000;
+    for (var i = 0; i < count; i++) {
+      var id = normalize(msg).messageId;
+      set[id] = true;
+    }
+    assert.lengthEquals(Object.keys(set), count);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5739,6 +5739,10 @@ source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
+spark-md5@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-2.0.2.tgz#37b763847763ae7e7acef2ca5233d01e649a78b7"
+
 spdx-correct@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.0.tgz#05a5b4d7153a195bc92c3c425b69f3b2a9524c82"


### PR DESCRIPTION
Currently message Ids are generated in the [Segmentio integration](https://github.com/segment-integrations/analytics.js-integration-segmentio/blob/master/lib/index.js#L316) for analytics.js. This moves the id generation logic further upstream so that client-side integrations can use the messageId. 

This will be deployed by releasing a commit of analytics.js-private that simultaneously pulls in:
- a version of a.js-core with the logic in this PR
- a version of the segmentio integration with the messageId generation logic removed.