### PR TITLE
feat(ids): check LocalStorage when cookies are not available

### DIFF
--- a/lib/entity.js
+++ b/lib/entity.js
@@ -106,10 +106,45 @@ Entity.prototype.id = function(id) {
  */
 
 Entity.prototype._getId = function() {
-  var ret = this._options.persist
-    ? this.storage().get(this._options.cookie.key)
-    : this._id;
-  return ret === undefined ? null : ret;
+  if (!this._options.persist) {
+    return this._id === undefined ? null : this._id;
+  }
+
+  // Check cookies.
+  var cookieId = this._getIdFromCookie();
+  if (cookieId) {
+    return cookieId;
+  }
+
+  // Check localStorage.
+  var lsId = this._getIdFromLocalStorage();
+  if (lsId) {
+    // Copy the id to cookies so we can read it directly from cookies next time.
+    this._setIdInCookies(lsId);
+    return lsId;
+  }
+
+  return null;
+};
+
+/**
+ * Get the entity's id from cookies.
+ *
+ * @return {String}
+ */
+
+Entity.prototype._getIdFromCookie = function() {
+  return this.storage().get(this._options.cookie.key);
+};
+
+/**
+ * Get the entity's id from cookies.
+ *
+ * @return {String}
+ */
+
+Entity.prototype._getIdFromLocalStorage = function() {
+  return store.get(this._options.cookie.key);
 };
 
 /**
@@ -120,10 +155,31 @@ Entity.prototype._getId = function() {
 
 Entity.prototype._setId = function(id) {
   if (this._options.persist) {
-    this.storage().set(this._options.cookie.key, id);
+    this._setIdInCookies(id);
+    this._setIdInLocalStorage(id);
   } else {
     this._id = id;
   }
+};
+
+/**
+ * Set the entity's `id` in cookies.
+ *
+ * @param {String} id
+ */
+
+Entity.prototype._setIdInCookies = function(id) {
+  this.storage().set(this._options.cookie.key, id);
+};
+
+/**
+ * Set the entity's `id` in local storage.
+ *
+ * @param {String} id
+ */
+
+Entity.prototype._setIdInLocalStorage = function(id) {
+  store.set(this._options.cookie.key, id);
 };
 
 /**
@@ -201,8 +257,8 @@ Entity.prototype.identify = function(id, traits) {
 
 Entity.prototype.save = function() {
   if (!this._options.persist) return false;
-  cookie.set(this._options.cookie.key, this.id());
-  store.set(this._options.localStorage.key, this.traits());
+  this._setId(this.id());
+  this._setTraits(this.traits());
   return true;
 };
 
@@ -213,7 +269,8 @@ Entity.prototype.save = function() {
 Entity.prototype.logout = function() {
   this.id(null);
   this.traits({});
-  cookie.remove(this._options.cookie.key);
+  this.storage().remove(this._options.cookie.key);
+  store.remove(this._options.cookie.key);
   store.remove(this._options.localStorage.key);
 };
 
@@ -231,6 +288,6 @@ Entity.prototype.reset = function() {
  */
 
 Entity.prototype.load = function() {
-  this.id(cookie.get(this._options.cookie.key));
-  this.traits(store.get(this._options.localStorage.key));
+  this.id(this.id());
+  this.traits(this.traits());
 };

--- a/lib/user.js
+++ b/lib/user.js
@@ -11,6 +11,7 @@ var debug = require('debug')('analytics:user');
 var inherit = require('inherits');
 var rawCookie = require('component-cookie');
 var uuid = require('uuid');
+var localStorage = require('./store');
 
 /**
  * User defaults
@@ -99,12 +100,25 @@ User.prototype.anonymousId = function(anonymousId) {
   // set / remove
   if (arguments.length) {
     store.set('ajs_anonymous_id', anonymousId);
+    localStorage.set('ajs_anonymous_id', anonymousId);
     return this;
   }
 
   // new
   anonymousId = store.get('ajs_anonymous_id');
   if (anonymousId) {
+    // value exist in cookie, copy it to localStorage
+    localStorage.set('ajs_anonymous_id', anonymousId);
+    // refresh cookie to extend expiry
+    store.set('ajs_anonymous_id', anonymousId);
+    return anonymousId;
+  }
+
+  // if anonymousId doesn't exist in cookies, check localStorage
+  anonymousId = localStorage.get('ajs_anonymous_id');
+  if (anonymousId) {
+    // Write to cookies if available in localStorage but not cookies
+    store.set('ajs_anonymous_id', anonymousId);
     return anonymousId;
   }
 
@@ -113,6 +127,7 @@ User.prototype.anonymousId = function(anonymousId) {
   if (anonymousId) {
     anonymousId = anonymousId.split('----')[0];
     store.set('ajs_anonymous_id', anonymousId);
+    localStorage.set('ajs_anonymous_id', anonymousId);
     store.remove('_sio');
     return anonymousId;
   }
@@ -120,6 +135,7 @@ User.prototype.anonymousId = function(anonymousId) {
   // empty
   anonymousId = uuid.v4();
   store.set('ajs_anonymous_id', anonymousId);
+  localStorage.set('ajs_anonymous_id', anonymousId);
   return store.get('ajs_anonymous_id');
 };
 

--- a/test/group.test.js
+++ b/test/group.test.js
@@ -39,6 +39,24 @@ describe('group', function() {
       assert(group.id() === 'gid');
       assert(group.traits().trait === true);
     });
+
+    it('id() should fallback to localStorage', function() {
+      var group = new Group();
+
+      group.id('gid');
+
+      // delete the cookie.
+      cookie.remove(cookieKey);
+
+      // verify cookie is deleted.
+      assert.equal(cookie.get(cookieKey), null);
+
+      // verify id() returns the id even when cookie is deleted.
+      assert.equal(group.id(), 'gid');
+
+      // verify cookie value is retored from localStorage.
+      assert.equal(cookie.get(cookieKey), 'gid');
+    });
   });
 
   describe('#id', function() {
@@ -226,6 +244,12 @@ describe('group', function() {
       assert(cookie.get(cookieKey) === 'id');
     });
 
+    it('should save an id to localStorage', function() {
+      group.id('id');
+      group.save();
+      assert(store.get(cookieKey) === 'id');
+    });
+
     it('should save properties to local storage', function() {
       group.properties({ property: true });
       group.save();
@@ -249,14 +273,21 @@ describe('group', function() {
       assert.deepEqual(group.properties(), {});
     });
 
-    it('should clear a cookie', function() {
+    it('should clear id in cookie', function() {
       group.id('id');
       group.save();
       group.logout();
       assert(cookie.get(cookieKey) === null);
     });
 
-    it('should clear local storage', function() {
+    it('should clear id in localStorage', function() {
+      group.id('id');
+      group.save();
+      group.logout();
+      assert(store.get(cookieKey) === undefined);
+    });
+
+    it('should clear traits in local storage', function() {
       group.properties({ property: true });
       group.save();
       group.logout();


### PR DESCRIPTION
This updates entity.js and user.js to dual write ids to localStorage and the cookies. This applies
to userId, groupId and anonymousIds. Reads will check the cookie first, and fallback to the
localStorage when a cookie is not available. When cookies are not available during reads, and
localStorage is, we write the value to the cookie as well.