### PR TITLE
feat(ids): add `localStorageFallbackDisabled` flag

### DIFF
--- a/lib/entity.js
+++ b/lib/entity.js
@@ -144,7 +144,10 @@ Entity.prototype._getIdFromCookie = function() {
  */
 
 Entity.prototype._getIdFromLocalStorage = function() {
-  return store.get(this._options.cookie.key);
+  if (!this._options.localStorageFallbackDisabled) {
+    return store.get(this._options.cookie.key);
+  }
+  return null;
 };
 
 /**
@@ -179,7 +182,9 @@ Entity.prototype._setIdInCookies = function(id) {
  */
 
 Entity.prototype._setIdInLocalStorage = function(id) {
-  store.set(this._options.cookie.key, id);
+  if (!this._options.localStorageFallbackDisabled) {
+    store.set(this._options.cookie.key, id);
+  }
 };
 
 /**

--- a/lib/user.js
+++ b/lib/user.js
@@ -100,26 +100,28 @@ User.prototype.anonymousId = function(anonymousId) {
   // set / remove
   if (arguments.length) {
     store.set('ajs_anonymous_id', anonymousId);
-    localStorage.set('ajs_anonymous_id', anonymousId);
+    this._setAnonymousIdInLocalStorage(anonymousId);
     return this;
   }
 
   // new
   anonymousId = store.get('ajs_anonymous_id');
   if (anonymousId) {
-    // value exist in cookie, copy it to localStorage
-    localStorage.set('ajs_anonymous_id', anonymousId);
+    // value exists in cookie, copy it to localStorage
+    this._setAnonymousIdInLocalStorage(anonymousId);
     // refresh cookie to extend expiry
     store.set('ajs_anonymous_id', anonymousId);
     return anonymousId;
   }
 
-  // if anonymousId doesn't exist in cookies, check localStorage
-  anonymousId = localStorage.get('ajs_anonymous_id');
-  if (anonymousId) {
-    // Write to cookies if available in localStorage but not cookies
-    store.set('ajs_anonymous_id', anonymousId);
-    return anonymousId;
+  if (!this._options.localStorageFallbackDisabled) {
+    // if anonymousId doesn't exist in cookies, check localStorage
+    anonymousId = localStorage.get('ajs_anonymous_id');
+    if (anonymousId) {
+      // Write to cookies if available in localStorage but not cookies
+      store.set('ajs_anonymous_id', anonymousId);
+      return anonymousId;
+    }
   }
 
   // old - it is not stringified so we use the raw cookie.
@@ -127,7 +129,7 @@ User.prototype.anonymousId = function(anonymousId) {
   if (anonymousId) {
     anonymousId = anonymousId.split('----')[0];
     store.set('ajs_anonymous_id', anonymousId);
-    localStorage.set('ajs_anonymous_id', anonymousId);
+    this._setAnonymousIdInLocalStorage(anonymousId);
     store.remove('_sio');
     return anonymousId;
   }
@@ -135,8 +137,20 @@ User.prototype.anonymousId = function(anonymousId) {
   // empty
   anonymousId = uuid.v4();
   store.set('ajs_anonymous_id', anonymousId);
-  localStorage.set('ajs_anonymous_id', anonymousId);
+  this._setAnonymousIdInLocalStorage(anonymousId);
   return store.get('ajs_anonymous_id');
+};
+
+/**
+ * Set the user's `anonymousid` in local storage.
+ *
+ * @param {String} id
+ */
+
+User.prototype._setAnonymousIdInLocalStorage = function(id) {
+  if (!this._options.localStorageFallbackDisabled) {
+    localStorage.set('ajs_anonymous_id', id);
+  }
 };
 
 /**

--- a/test/group.test.js
+++ b/test/group.test.js
@@ -57,6 +57,24 @@ describe('group', function() {
       // verify cookie value is retored from localStorage.
       assert.equal(cookie.get(cookieKey), 'gid');
     });
+
+    it('id() should not fallback to localStorage when localStorage fallback is disabled', function() {
+      var group = new Group();
+      group.options({
+        localStorageFallbackDisabled: true
+      });
+
+      group.id('gid');
+
+      // delete the cookie.
+      cookie.remove(cookieKey);
+
+      // verify cookie is deleted.
+      assert.equal(cookie.get(cookieKey), null);
+
+      // verify id() does not return the id when cookie is deleted.
+      assert.equal(group.id(), null);
+    });
   });
 
   describe('#id', function() {
@@ -248,6 +266,16 @@ describe('group', function() {
       group.id('id');
       group.save();
       assert(store.get(cookieKey) === 'id');
+    });
+
+    it('should not save an id to localStorage when localStorage fallback is disabled', function() {
+      group.options({
+        localStorageFallbackDisabled: true
+      });
+
+      group.id('id');
+      group.save();
+      assert.equal(store.get(cookieKey), null);
     });
 
     it('should save properties to local storage', function() {

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -57,8 +57,26 @@ describe('user', function() {
       // verify id() returns the id even when cookie is deleted.
       assert.equal(user.id(), 'id');
 
-      // verify cookie value is retored from localStorage.
+      // verify cookie value is restored from localStorage.
       assert.equal(cookie.get(cookieKey), 'id');
+    });
+
+    it('id() should not fallback to localStorage when disabled', function() {
+      var user = new User();
+      user.options({
+        localStorageFallbackDisabled: true
+      });
+
+      user.id('id');
+
+      // delete the cookie.
+      cookie.remove(cookieKey);
+
+      // verify cookie is deleted.
+      assert.equal(cookie.get(cookieKey), null);
+
+      // verify id() does not return the id when cookie is deleted.
+      assert.equal(user.id(), null);
     });
 
     it('should pick the old "_sio" anonymousId', function() {
@@ -345,11 +363,31 @@ describe('user', function() {
         assert.equal(store.get('ajs_anonymous_id'), 'anon0');
       });
 
+      it('should not set anonymousId in localStorage when localStorage fallback is disabled', function() {
+        var user = new User();
+        user.options({
+          localStorageFallbackDisabled: true
+        });
+        user.anonymousId('anon0');
+        assert.equal(cookie.get('ajs_anonymous_id'), 'anon0');
+        assert.equal(store.get('ajs_anonymous_id'), null);
+      });
+
       it('should copy value from cookie to localStorage', function() {
         var user = new User();
         cookie.set('ajs_anonymous_id', 'anon1');
         assert.equal(user.anonymousId(), 'anon1');
         assert.equal(store.get('ajs_anonymous_id'), 'anon1');
+      });
+
+      it('should not copy value from cookie to localStorage when localStorage fallback is disabled', function() {
+        var user = new User();
+        user.options({
+          localStorageFallbackDisabled: true
+        });
+        cookie.set('ajs_anonymous_id', 'anon1');
+        assert.equal(user.anonymousId(), 'anon1');
+        assert.equal(store.get('ajs_anonymous_id'), null);
       });
 
       it('should fall back to localStorage when cookie is not set', function() {
@@ -365,8 +403,25 @@ describe('user', function() {
         // verify anonymousId() returns the correct id even when there's no cookie
         assert.equal(user.anonymousId(), 'anon12');
 
-        // verify cookie value is retored from localStorage
+        // verify cookie value is restored from localStorage
         assert.equal(cookie.get('ajs_anonymous_id'), 'anon12');
+      });
+
+      it('should not fall back to localStorage when cookie is not set and localStorage fallback is disabled', function() {
+        var user = new User();
+        user.options({
+          localStorageFallbackDisabled: true
+        });
+
+        user.anonymousId('anon12');
+        assert.equal(cookie.get('ajs_anonymous_id'), 'anon12');
+
+        // delete the cookie
+        cookie.remove('ajs_anonymous_id');
+        assert.equal(cookie.get('ajs_anonymous_id'), null);
+
+        // verify anonymousId() does not return the id when there's no cookie.
+        assert.notEqual(user.anonymousId(), 'anon12');
       });
 
       it('should write to both cookie and localStorage when generating a new anonymousId', function() {
@@ -375,6 +430,19 @@ describe('user', function() {
         assert.notEqual(anonId, null);
         assert.equal(cookie.get('ajs_anonymous_id'), anonId);
         assert.equal(store.get('ajs_anonymous_id'), anonId);
+      });
+
+      it('should not write to both cookie and localStorage when generating a new anonymousId and localStorage fallback is disabled', function() {
+        var user = new User();
+        user.options({
+          localStorageFallbackDisabled: true
+        });
+
+        var anonId = user.anonymousId();
+
+        assert.notEqual(anonId, null);
+        assert.equal(cookie.get('ajs_anonymous_id'), anonId);
+        assert.equal(store.get('ajs_anonymous_id'), null);
       });
     });
   });
@@ -461,6 +529,17 @@ describe('user', function() {
       user.id('id');
       user.save();
       assert.equal(store.get(cookieKey), 'id');
+    });
+
+    it('should not save an id to localStorage when localStorage fallback is disabled', function() {
+      user.options({
+        localStorageFallbackDisabled: true
+      });
+      user.id('id');
+
+      user.save();
+
+      assert.equal(store.get(cookieKey), null);
     });
 
     it('should save traits to local storage', function() {


### PR DESCRIPTION
This adds a flag `localStorageFallbackDisabled` to disable the localStorage fallback code.

`localStorageFallbackDisabled` is falsy by default, hence the fallback code is opt in by default, and requires opt out.

Since the configuration for users and groups are supplied seperately, to use this you need to pass in:

```
analytics.initialize(settings, {
  user: {
    localStorageFallbackDisabled: true,
  },
  group: {
   localStorageFallbackDisabled: true
  }
})
```