### PR TITLE
feat(analytics.js) emit integration errors

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -699,6 +699,7 @@ Analytics.prototype._invoke = function(method, facade) {
           method: method,
           integration_name: integration.name
         });
+        self.emit('error', e);
         self.log(
           'Error invoking .%s method of %s integration: %o',
           method,

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -414,6 +414,14 @@ describe('Analytics', function() {
       assert(b.traits().trait === true);
     });
 
+    it('should emit an error event with the error object', function() {
+      var a = new Identify({ userId: 'id', traits: { trait: true } });
+      Test.prototype.invoke = function() {
+        throw new Error('Ruh Ro!');
+      };
+      analytics._invoke('identify', a);
+    });
+
     it('shouldnt call a method when the `all` option is false', function() {
       var opts = { providers: { all: false } };
       var facade = new Facade({ options: opts });


### PR DESCRIPTION
Currently, analytics.js will swallow all errors that get triggered in an integration. This is necessary to avoid a panic and ensure other integrations can run but it makes it very difficult to debug issues when making local changes. 

This PR simply emits the error in the catch block to allow clients to log them when debugging.