### PR TITLE
Add middleware support

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -105,7 +105,7 @@ Analytics.prototype.addIntegrationMiddleware = function(Middleware) {
     throw new Error('attempted to add middleware after initialization');
 
   // Check for identical object references - bug check.
-  for (var i = 0; i < this.Middlewares.length; i++) {
+  for (var i = 0; i < this.IntegrationMiddlewares.length; i++) {
     if (this.IntegrationMiddlewares[i] === Middleware)
       throw new Error('middleware is already registered');
   }

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -716,13 +716,16 @@ Analytics.prototype._invoke = function(method, facade) {
             self.log('Payload to integration "%s" was null and dropped.', name);
             return;
           }
-          facadeCopy.obj = payload;
+
+          var facadeAfterMiddleware = extend(true, {}, facadeCopy, {
+            obj: payload
+          });
           metrics.increment('analytics_js.integration.invoke', {
             method: method,
             integration_name: integration.name
           });
 
-          integration.invoke.call(integration, method, facadeCopy);
+          integration.invoke.call(integration, method, facadeAfterMiddleware);
         });
       } catch (e) {
         metrics.increment('analytics_js.integration.invoke.error', {

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -101,11 +101,11 @@ Analytics.prototype.addIntegration = function(Integration) {
  * @return {Analytics}
  */
 
-Analytics.prototype.addIntegrationMiddleware = function(Middleware) {
+Analytics.prototype.addIntegrationMiddleware = function(middleware) {
   if (this.initialized)
     throw new Error('attempted to add middleware after initialization');
 
-  this._integrationMiddlewares.add(Middleware);
+  this._integrationMiddlewares.add(middleware);
   return this;
 };
 

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -711,6 +711,7 @@ Analytics.prototype._invoke = function(method, facade) {
         self._integrationMiddlewares.applyMiddlewares(facadeCopy.obj, function(
           payload
         ) {
+          // A nullified payload should not be sent to an integration.
           if (payload === null) return;
           facadeCopy.obj = payload;
           metrics.increment('analytics_js.integration.invoke', {

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -712,7 +712,13 @@ Analytics.prototype._invoke = function(method, facade) {
           payload
         ) {
           // A nullified payload should not be sent to an integration.
-          if (payload === null) return;
+          if (payload === null) {
+            self.log(
+              '' + 'Payload to integration "%s" was null and dropped.',
+              name
+            );
+            return;
+          }
           facadeCopy.obj = payload;
           metrics.increment('analytics_js.integration.invoke', {
             method: method,

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -712,9 +712,9 @@ Analytics.prototype._invoke = function(method, facade) {
         self._integrationMiddlewares.applyMiddlewares(
           facadeCopy,
           integration.name,
-          function(facadeResult) {
+          function(result) {
             // A nullified payload should not be sent to an integration.
-            if (facadeResult === null) {
+            if (result === null) {
               self.log(
                 'Payload to integration "%s" was null and dropped.',
                 name
@@ -722,12 +722,17 @@ Analytics.prototype._invoke = function(method, facade) {
               return;
             }
 
+            // Check if the payload is still a Facade. If not, convert it to one.
+            if (!(result instanceof Facade)) {
+              result = new Facade(result);
+            }
+
             metrics.increment('analytics_js.integration.invoke', {
               method: method,
               integration_name: integration.name
             });
 
-            integration.invoke.call(integration, method, facadeResult);
+            integration.invoke.call(integration, method, result);
           }
         );
       } catch (e) {

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -8,6 +8,7 @@ var _analytics = global.analytics;
 
 var Alias = require('segmentio-facade').Alias;
 var Emitter = require('component-emitter');
+var Facade = require('segmentio-facade');
 var Group = require('segmentio-facade').Group;
 var Identify = require('segmentio-facade').Identify;
 var MiddlewareChain = require('./middleware').Chain;
@@ -694,7 +695,7 @@ Analytics.prototype._invoke = function(method, facade) {
 
   var failedInitializations = self.failedInitializations || [];
   each(function(integration, name) {
-    var facadeCopy = extend(true, {}, facade);
+    var facadeCopy = extend(true, new Facade({}), facade);
 
     if (!facadeCopy.enabled(name)) return;
     // Check if an integration failed to initialize.
@@ -708,25 +709,27 @@ Analytics.prototype._invoke = function(method, facade) {
     } else {
       try {
         // Apply any integration middlewares that exist, then invoke the integration with the result.
-        self._integrationMiddlewares.applyMiddlewares(facadeCopy.obj, function(
-          payload
-        ) {
-          // A nullified payload should not be sent to an integration.
-          if (payload === null) {
-            self.log('Payload to integration "%s" was null and dropped.', name);
-            return;
+        self._integrationMiddlewares.applyMiddlewares(
+          facadeCopy,
+          integration.name,
+          function(facadeResult) {
+            // A nullified payload should not be sent to an integration.
+            if (facadeResult === null) {
+              self.log(
+                'Payload to integration "%s" was null and dropped.',
+                name
+              );
+              return;
+            }
+
+            metrics.increment('analytics_js.integration.invoke', {
+              method: method,
+              integration_name: integration.name
+            });
+
+            integration.invoke.call(integration, method, facadeResult);
           }
-
-          var facadeAfterMiddleware = extend(true, {}, facadeCopy, {
-            obj: payload
-          });
-          metrics.increment('analytics_js.integration.invoke', {
-            method: method,
-            integration_name: integration.name
-          });
-
-          integration.invoke.call(integration, method, facadeAfterMiddleware);
-        });
+        );
       } catch (e) {
         metrics.increment('analytics_js.integration.invoke.error', {
           method: method,

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -711,7 +711,6 @@ Analytics.prototype._invoke = function(method, facade) {
         self.IntegrationMiddlewares.applyMiddlewares(facadeCopy.obj, function(
           payload
         ) {
-          console.log('INVOKE APPLY MIDDLEWARES:', payload);
           if (payload === null) return;
           facadeCopy.obj = payload;
           metrics.increment('analytics_js.integration.invoke', {

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -106,11 +106,11 @@ Analytics.prototype.addIntegrationMiddleware = function(Middleware) {
 
   // Check for identical object references - bug check.
   for (var i = 0; i < this.Middlewares.length; i++) {
-    if (this.Middlewares[i] === Middleware)
+    if (this.IntegrationMiddlewares[i] === Middleware)
       throw new Error('middleware is already registered');
   }
 
-  this.Middlewares.push(Middleware);
+  this.IntegrationMiddlewares.push(Middleware);
   return this;
 };
 

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -45,6 +45,7 @@ var type = require('component-type');
 function Analytics() {
   this._options({});
   this.Integrations = {};
+  this.IntegrationMiddlewares = [];
   this._integrations = {};
   this._readied = false;
   this._timeout = 300;
@@ -89,6 +90,27 @@ Analytics.prototype.addIntegration = function(Integration) {
   var name = Integration.prototype.name;
   if (!name) throw new TypeError('attempted to add an invalid integration');
   this.Integrations[name] = Integration;
+  return this;
+};
+
+/**
+ * Define a new `IntegrationMiddleware`
+ *
+ * @param {Function} Middleware
+ * @return {Analytics}
+ */
+
+Analytics.prototype.addIntegrationMiddleware = function(Middleware) {
+  if (this.initialized)
+    throw new Error('attempted to add middleware after initialization');
+
+  // Check for identical object references - bug check.
+  for (var i = 0; i < this.Middlewares.length; i++) {
+    if (this.Middlewares[i] === Middleware)
+      throw new Error('middleware is already registered');
+  }
+
+  this.Middlewares.push(Middleware);
   return this;
 };
 
@@ -189,8 +211,7 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(
     }
   }, integrations);
 
-  // backwards compat with angular plugin.
-  // TODO: remove
+  // backwards compat with angular plugin and used for init logic checks
   this.initialized = true;
 
   this.emit('initialize', settings, options);
@@ -678,7 +699,9 @@ Analytics.prototype._invoke = function(method, facade) {
 
   var failedInitializations = self.failedInitializations || [];
   each(function(integration, name) {
-    if (!facade.enabled(name)) return;
+    var facadeCopy = extend({}, facade);
+
+    if (!facadeCopy.enabled(name)) return;
     // Check if an integration failed to initialize.
     // If so, do not process the message as the integration is in an unstable state.
     if (failedInitializations.indexOf(name) >= 0) {
@@ -693,7 +716,11 @@ Analytics.prototype._invoke = function(method, facade) {
           method: method,
           integration_name: integration.name
         });
-        integration.invoke.call(integration, method, facade);
+
+        self._applyIntegrationMiddlewares(facadeCopy.obj);
+        if (facadeCopy.obj === null) return; // TODO - Some middlewares can and will null payloads. Is best practice to handle it here? Or for middleware owners to handle?
+
+        integration.invoke.call(integration, method, facadeCopy);
       } catch (e) {
         metrics.increment('analytics_js.integration.invoke.error', {
           method: method,
@@ -835,6 +862,24 @@ Analytics.prototype._mergeInitializeAndPlanIntegrations = function(
   }
 
   return integrations;
+};
+
+/**
+ * Applies all integration middlewares in-order to the payload and returns the result.
+ *
+ * @param {Object} payload AJS Payload to be sent to an integration.
+ * @return {Object} Modified AJS Payload
+ * @private
+ */
+Analytics.prototype._applyIntegrationMiddlewares = function(payload) {
+  for (var i = 0; i < this.IntegrationMiddlewares.length; i++) {
+    if (!payload) break; // TODO - Some middlewares can and will null payloads. Is best practice to handle it here? Or for middleware owners to handle?
+
+    var middleware = this.IntegrationMiddlewares[i];
+    payload = middleware(payload);
+  }
+
+  return payload;
 };
 
 /**

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -713,10 +713,7 @@ Analytics.prototype._invoke = function(method, facade) {
         ) {
           // A nullified payload should not be sent to an integration.
           if (payload === null) {
-            self.log(
-              '' + 'Payload to integration "%s" was null and dropped.',
-              name
-            );
+            self.log('Payload to integration "%s" was null and dropped.', name);
             return;
           }
           facadeCopy.obj = payload;

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -46,7 +46,7 @@ var type = require('component-type');
 function Analytics() {
   this._options({});
   this.Integrations = {};
-  this.IntegrationMiddlewares = new MiddlewareChain();
+  this._integrationMiddlewares = new MiddlewareChain();
   this._integrations = {};
   this._readied = false;
   this._timeout = 300;
@@ -105,7 +105,7 @@ Analytics.prototype.addIntegrationMiddleware = function(Middleware) {
   if (this.initialized)
     throw new Error('attempted to add middleware after initialization');
 
-  this.IntegrationMiddlewares.add(Middleware);
+  this._integrationMiddlewares.add(Middleware);
   return this;
 };
 
@@ -708,7 +708,7 @@ Analytics.prototype._invoke = function(method, facade) {
     } else {
       try {
         // Apply any integration middlewares that exist, then invoke the integration with the result.
-        self.IntegrationMiddlewares.applyMiddlewares(facadeCopy.obj, function(
+        self._integrationMiddlewares.applyMiddlewares(facadeCopy.obj, function(
           payload
         ) {
           if (payload === null) return;

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -10,6 +10,7 @@ var Alias = require('segmentio-facade').Alias;
 var Emitter = require('component-emitter');
 var Group = require('segmentio-facade').Group;
 var Identify = require('segmentio-facade').Identify;
+var MiddlewareChain = require('./middleware').Chain;
 var Page = require('segmentio-facade').Page;
 var Track = require('segmentio-facade').Track;
 var after = require('@ndhoule/after');
@@ -45,7 +46,7 @@ var type = require('component-type');
 function Analytics() {
   this._options({});
   this.Integrations = {};
-  this.IntegrationMiddlewares = [];
+  this.IntegrationMiddlewares = new MiddlewareChain();
   this._integrations = {};
   this._readied = false;
   this._timeout = 300;
@@ -104,13 +105,7 @@ Analytics.prototype.addIntegrationMiddleware = function(Middleware) {
   if (this.initialized)
     throw new Error('attempted to add middleware after initialization');
 
-  // Check for identical object references - bug check.
-  for (var i = 0; i < this.IntegrationMiddlewares.length; i++) {
-    if (this.IntegrationMiddlewares[i] === Middleware)
-      throw new Error('middleware is already registered');
-  }
-
-  this.IntegrationMiddlewares.push(Middleware);
+  this.IntegrationMiddlewares.add(Middleware);
   return this;
 };
 
@@ -699,28 +694,33 @@ Analytics.prototype._invoke = function(method, facade) {
 
   var failedInitializations = self.failedInitializations || [];
   each(function(integration, name) {
-    var facadeCopy = extend({}, facade);
+    var facadeCopy = extend(true, {}, facade);
 
     if (!facadeCopy.enabled(name)) return;
     // Check if an integration failed to initialize.
     // If so, do not process the message as the integration is in an unstable state.
     if (failedInitializations.indexOf(name) >= 0) {
       self.log(
-        'Skipping invokation of .%s method of %s integration. Integation failed to initialize properly.',
+        'Skipping invocation of .%s method of %s integration. Integration failed to initialize properly.',
         method,
         name
       );
     } else {
       try {
-        metrics.increment('analytics_js.integration.invoke', {
-          method: method,
-          integration_name: integration.name
+        // Apply any integration middlewares that exist, then invoke the integration with the result.
+        self.IntegrationMiddlewares.applyMiddlewares(facadeCopy.obj, function(
+          payload
+        ) {
+          console.log('INVOKE APPLY MIDDLEWARES:', payload);
+          if (payload === null) return;
+          facadeCopy.obj = payload;
+          metrics.increment('analytics_js.integration.invoke', {
+            method: method,
+            integration_name: integration.name
+          });
+
+          integration.invoke.call(integration, method, facadeCopy);
         });
-
-        self._applyIntegrationMiddlewares(facadeCopy.obj);
-        if (facadeCopy.obj === null) return; // TODO - Some middlewares can and will null payloads. Is best practice to handle it here? Or for middleware owners to handle?
-
-        integration.invoke.call(integration, method, facadeCopy);
       } catch (e) {
         metrics.increment('analytics_js.integration.invoke.error', {
           method: method,
@@ -862,24 +862,6 @@ Analytics.prototype._mergeInitializeAndPlanIntegrations = function(
   }
 
   return integrations;
-};
-
-/**
- * Applies all integration middlewares in-order to the payload and returns the result.
- *
- * @param {Object} payload AJS Payload to be sent to an integration.
- * @return {Object} Modified AJS Payload
- * @private
- */
-Analytics.prototype._applyIntegrationMiddlewares = function(payload) {
-  for (var i = 0; i < this.IntegrationMiddlewares.length; i++) {
-    if (!payload) break; // TODO - Some middlewares can and will null payloads. Is best practice to handle it here? Or for middleware owners to handle?
-
-    var middleware = this.IntegrationMiddlewares[i];
-    payload = middleware(payload);
-  }
-
-  return payload;
 };
 
 /**

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -44,6 +44,12 @@ function Chain() {
 
 // Go over all middlewares until all have been applied.
 function executeChain(payload, middlewares, index) {
+  // If the payload has been nullified, immediately skip to the final middleware.
+  if (payload === null) {
+    middlewares[middlewares.length - 1](payload);
+    return;
+  }
+
   var mw = middlewares[index];
   if (mw) {
     // If there's another middleware, continue down the chain. Otherwise, call the final function.

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -28,7 +28,9 @@ function Chain() {
 
   // fn is the callback to be run once all middlewares have been applied.
   this.applyMiddlewares = function(payload, fn) {
-    if (typeof payload !== 'object' || payload === null)
+    // Null payloads are OK and should be handled by the middlewares appropriately (e.g. a middleware that handles
+    // logging or triggering additional, different calls on a nullified payload).
+    if (typeof payload !== 'object')
       throw new Error('applyMiddlewares requires a payload object');
     if (typeof fn !== 'function')
       throw new Error('applyMiddlewares requires a function callback');

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -52,8 +52,8 @@ function executeChain(payload, integration, middlewares, index) {
   if (mw) {
     // If there's another middleware, continue down the chain. Otherwise, call the final function.
     if (middlewares[index + 1]) {
-      mw(payload, integration, function(newFacade) {
-        executeChain(newFacade, integration, middlewares, ++index);
+      mw(payload, integration, function(result) {
+        executeChain(result, integration, middlewares, ++index);
       });
     } else {
       mw(payload);

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var Facade = require('segmentio-facade');
+
 // Chain is essentially a linked list of middlewares to run in order.
 function Chain() {
   var middlewares = [];
@@ -20,10 +22,8 @@ function Chain() {
   };
 
   // fn is the callback to be run once all middlewares have been applied.
-  this.applyMiddlewares = function(payload, fn) {
-    // Null payloads are OK and should be handled by the middlewares appropriately (e.g. a middleware that handles
-    // logging or triggering additional, different calls on a nullified payload).
-    if (typeof payload !== 'object')
+  this.applyMiddlewares = function(facade, integration, fn) {
+    if (typeof facade !== 'object')
       throw new Error('applyMiddlewares requires a payload object');
     if (typeof fn !== 'function')
       throw new Error('applyMiddlewares requires a function callback');
@@ -31,24 +31,29 @@ function Chain() {
     // Attach callback to the end of the chain.
     var middlewaresToApply = middlewares.slice();
     middlewaresToApply.push(fn);
-    executeChain(payload, middlewaresToApply, 0);
+    executeChain(facade, integration, middlewaresToApply, 0);
   };
 }
 
 // Go over all middlewares until all have been applied.
-function executeChain(payload, middlewares, index) {
-  // If the payload has been nullified, immediately skip to the final middleware.
+function executeChain(payload, integration, middlewares, index) {
+  // If the facade has been nullified, immediately skip to the final middleware.
   if (payload === null) {
-    middlewares[middlewares.length - 1](payload);
+    middlewares[middlewares.length - 1](null);
     return;
+  }
+
+  // Check if the payload is still a Facade. If not, convert it to one.
+  if (!(payload instanceof Facade)) {
+    payload = new Facade(payload);
   }
 
   var mw = middlewares[index];
   if (mw) {
     // If there's another middleware, continue down the chain. Otherwise, call the final function.
     if (middlewares[index + 1]) {
-      mw(payload, function(newPayload) {
-        executeChain(newPayload, middlewares, ++index);
+      mw(payload, integration, function(newFacade) {
+        executeChain(newFacade, integration, middlewares, ++index);
       });
     } else {
       mw(payload);

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -2,28 +2,21 @@
 
 // Chain is essentially a linked list of middlewares to run in order.
 function Chain() {
-  var self = this;
   var middlewares = [];
 
+  // Return a copy to prevent external mutations.
   this.getMiddlewares = function() {
-    return middlewares;
+    return middlewares.slice();
   };
 
   this.add = function(middleware) {
     if (typeof middleware !== 'function')
       throw new Error('attempted to add non-function middleware');
-    if (self.contains(middleware))
+
+    // Check for identical object references - bug check.
+    if (middlewares.indexOf(middleware) !== -1)
       throw new Error('middleware is already registered');
     middlewares.push(middleware);
-  };
-
-  // Check for identical object references - bug check.
-  this.contains = function(middleware) {
-    for (var i = 0; i < middlewares.length; i++) {
-      if (middleware === middlewares[i]) return true;
-    }
-
-    return false;
   };
 
   // fn is the callback to be run once all middlewares have been applied.

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,0 +1,58 @@
+'use strict';
+
+// Chain is essentially a linked list of middlewares to run in order.
+function Chain() {
+  var self = this;
+  var middlewares = [];
+
+  this.getMiddlewares = function() {
+    return middlewares;
+  };
+
+  this.add = function(middleware) {
+    if (typeof middleware !== 'function')
+      throw new Error('attempted to add non-function middleware');
+    if (self.contains(middleware))
+      throw new Error('middleware is already registered');
+    middlewares.push(middleware);
+  };
+
+  // Check for identical object references - bug check.
+  this.contains = function(middleware) {
+    for (var i = 0; i < middlewares.length; i++) {
+      if (middleware === middlewares[i]) return true;
+    }
+
+    return false;
+  };
+
+  // fn is the callback to be run once all middlewares have been applied.
+  this.applyMiddlewares = function(payload, fn) {
+    if (typeof payload !== 'object' || payload === null)
+      throw new Error('applyMiddlewares requires a payload object');
+    if (typeof fn !== 'function')
+      throw new Error('applyMiddlewares requires a function callback');
+
+    // Attach callback to the end of the chain.
+    var middlewaresToApply = middlewares.slice();
+    middlewaresToApply.push(fn);
+    executeChain(payload, middlewaresToApply, 0);
+  };
+}
+
+// Go over all middlewares until all have been applied.
+function executeChain(payload, middlewares, index) {
+  var mw = middlewares[index];
+  if (mw) {
+    // If there's another middleware, continue down the chain. Otherwise, call the final function.
+    if (middlewares[index + 1]) {
+      mw(payload, function(newPayload) {
+        executeChain(newPayload, middlewares, ++index);
+      });
+    } else {
+      mw(payload);
+    }
+  }
+}
+
+module.exports.Chain = Chain;

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "component-type": "^1.2.1",
     "component-url": "^0.2.1",
     "debug": "^0.7.4",
-    "extend": "3.0.1",
+    "extend": "3.0.2",
     "inherits": "^2.0.1",
     "install": "^0.7.3",
     "is": "^3.1.0",

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -409,7 +409,6 @@ describe('Analytics', function() {
       var a = new Identify({ userId: 'id', traits: { trait: true } });
       analytics._invoke('identify', a);
       var b = Test.prototype.invoke.args[0][1];
-      assert(b === a);
       assert(b.userId() === 'id');
       assert(b.traits().trait === true);
     });
@@ -452,7 +451,7 @@ describe('Analytics', function() {
       );
     });
 
-    it('should record a metric when invoking an integration', function() {
+    it('should record a metric when invoking an integration and getting an error', function() {
       Test.prototype.invoke = function() {
         throw new Error('Uh oh!');
       };

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -2004,4 +2004,52 @@ describe('Analytics', function() {
       assert.deepEqual({}, group.traits());
     });
   });
+
+  describe('#addIntegrationMiddleware', function() {
+    it('should have a defined _integrationMiddlewares property', function() {
+      assert(analytics._integrationMiddlewares !== undefined);
+    });
+
+    it('should allow users to add a valid Middleware', function() {
+      try {
+        analytics.addIntegrationMiddleware(function() {});
+      } catch (e) {
+        // This assert should not run.
+        assert(false, 'error was incorrectly thrown!');
+      }
+    });
+
+    it('should throw an error if the selected Middleware is not a function', function() {
+      try {
+        analytics.addIntegrationMiddleware(7);
+
+        // This assert should not run.
+        assert(false, 'error was not thrown!');
+      } catch (e) {
+        assert(
+          e.message === 'attempted to add non-function middleware',
+          'wrong error return'
+        );
+      }
+    });
+
+    it('should throw an error if AJS has already initialized', function() {
+      analytics.init();
+      try {
+        analytics.addIntegrationMiddleware(function() {});
+
+        // This assert should not run.
+        assert(false, 'error was not thrown!');
+      } catch (e) {
+        assert(
+          e.message === 'attempted to add middleware after initialization',
+          'wrong error return'
+        );
+      }
+    });
+
+    it('should return the analytics object', function() {
+      assert(analytics === analytics.addIntegrationMiddleware(function() {}));
+    });
+  });
 });

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -138,4 +138,21 @@ describe('middleware', function() {
       assert.deepEqual(payload.test, [1, 2, 3]);
     });
   });
+
+  it('should stop running middlewares if payload becomes null', function() {
+    chain.add(function(payload, next) {
+      payload.test.push(1);
+      next(payload);
+    });
+    chain.add(function(payload, next) {
+      next(null);
+    });
+    chain.add(function() {
+      throw new Error('Middleware chain was not interrupted by null!');
+    });
+
+    chain.applyMiddlewares({ test: [] }, function(payload) {
+      assert(payload === null, 'payload was not nullified');
+    });
+  });
 });

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -1,0 +1,148 @@
+'use strict';
+
+var assert = require('proclaim');
+var MiddlewareChain = require('../lib/middleware').Chain;
+
+describe('middleware', function() {
+  var chain;
+  beforeEach(function() {
+    chain = new MiddlewareChain();
+  });
+
+  describe('#getMiddlewares', function() {
+    it('should start empty', function() {
+      assert.deepEqual(chain.getMiddlewares(), []);
+    });
+
+    it('should get existing middlewares', function() {
+      chain.add(function() {
+        return 'Valid! :)';
+      });
+
+      var middlewares = chain.getMiddlewares();
+      assert(middlewares.length === 1, 'wrong middleware count');
+      assert(middlewares[0]() === 'Valid! :)', 'wrong middleware return');
+    });
+  });
+
+  describe('#add', function() {
+    it('should not allow non-functions to be added', function() {
+      try {
+        chain.add({ 'this is': 'not a function' });
+
+        // This assert should not run.
+        assert(false, 'error was not thrown!');
+      } catch (e) {
+        assert(
+          e.message === 'attempted to add non-function middleware',
+          'wrong error return'
+        );
+      }
+    });
+
+    it('should not allow the same middleware instance to be added multiple times', function() {
+      var middleware = function() {};
+
+      chain.add(middleware);
+      assert(chain.getMiddlewares().length === 1, 'wrong middleware count');
+
+      try {
+        chain.add(middleware);
+
+        // This assert should not run.
+        assert(false, 'error was not thrown!');
+      } catch (e) {
+        assert(
+          e.message === 'middleware is already registered',
+          'wrong error return'
+        );
+      }
+    });
+
+    it('should be able to add multiple different middlewares', function() {
+      // Same literal values, but different instances.
+      chain.add(function() {});
+      chain.add(function() {});
+      chain.add(function() {});
+      assert(chain.getMiddlewares().length === 3, 'wrong middleware count');
+    });
+  });
+
+  describe('#applyMiddlewares', function() {
+    it('should require a function callback', function() {
+      try {
+        chain.applyMiddlewares({});
+      } catch (e) {
+        assert(
+          e.message === 'applyMiddlewares requires a function callback',
+          'wrong error return'
+        );
+      }
+
+      try {
+        chain.applyMiddlewares({}, ['this is not a function =(']);
+      } catch (e) {
+        assert(
+          e.message === 'applyMiddlewares requires a function callback',
+          'wrong error return'
+        );
+      }
+    });
+  });
+
+  it('should require a payload object', function() {
+    try {
+      chain.applyMiddlewares(7, function() {
+        // This assert should not run.
+        assert(false, 'error was not thrown!');
+      });
+    } catch (e) {
+      assert(
+        e.message === 'applyMiddlewares requires a payload object',
+        'wrong error return'
+      );
+    }
+
+    try {
+      chain.applyMiddlewares(null, function() {
+        // This assert should not run.
+        assert(false, 'error was not thrown!');
+      });
+    } catch (e) {
+      assert(
+        e.message === 'applyMiddlewares requires a payload object',
+        'wrong error return'
+      );
+    }
+  });
+
+  it('should apply a middleware', function() {
+    chain.add(function(payload, next) {
+      payload.testVal = 'success';
+      next(payload);
+    });
+
+    chain.applyMiddlewares({}, function(payload) {
+      assert(payload.testVal === 'success', 'payload value incorrectly set');
+    });
+  });
+
+  it('should apply multiple middlewares in order', function() {
+    chain.add(function(payload, next) {
+      payload.test.push(1);
+      next(payload);
+    });
+    chain.add(function(payload, next) {
+      payload.test.push(2);
+      next(payload);
+    });
+    chain.add(function(payload, next) {
+      payload.test.push(3);
+      next(payload);
+    });
+
+    chain.applyMiddlewares({ test: [] }, function(payload) {
+      assert.deepEqual(payload.test, [1, 2, 3]);
+    });
+  });
+});

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -103,17 +103,10 @@ describe('middleware', function() {
       );
     }
 
-    try {
-      chain.applyMiddlewares(null, function() {
-        // This assert should not run.
-        assert(false, 'error was not thrown!');
-      });
-    } catch (e) {
-      assert(
-        e.message === 'applyMiddlewares requires a payload object',
-        'wrong error return'
-      );
-    }
+    chain.applyMiddlewares(null, function(payload) {
+      // This assert SHOULD run.
+      assert(payload === null, 'payload should have been null');
+    });
   });
 
   it('should apply a middleware', function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2443,6 +2443,11 @@ extend@3, extend@3.0.1, extend@^3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
+extend@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
 external-editor@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-1.1.1.tgz#12d7b0db850f7ff7e7081baf4005700060c4600b"


### PR DESCRIPTION
This PR moves to add integration-level middleware support to analytics.js. It does so by exposing a new property called `_integrationMiddlewares`. To easily allow users and applications to interface with this long-term, we expose an `addIntegrationMiddleware` method that'll be the entrypoint going forward.

Middlwares are expected to accept two arguments - an object payload and a function callback. A final "middleware" callback is appended to continue the normal ajs call pipeline once all middlewares - if any - have been applied.

CC @f2prateek for first review so we can clean up anything desired and get this out the door! :)