### PR TITLE
remove after dependency

### DIFF
--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -215,7 +215,8 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(
         if (initialPageSkipped) {
           return page.apply(this, arguments);
         }
-        return (initialPageSkipped = true);
+        initialPageSkipped = true;
+        return;
       };
     }
 

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -53,7 +53,6 @@ function Analytics() {
   this._integrations = {};
   this._readied = false;
   this._timeout = 300;
-  this._callCount = 0;
   // XXX: BACKWARDS COMPATIBILITY
   this._user = user;
   this.log = debug('analytics.js');
@@ -186,10 +185,11 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(
   group.load();
 
   // make ready callback
+  var readyCallCount = 0;
   var integrationCount = keys(integrations).length;
   var ready = function() {
-    self._callCount++;
-    if (self._callCount >= integrationCount) {
+    readyCallCount++;
+    if (readyCallCount >= integrationCount) {
       self._readied = true;
       self.emit('ready');
     }

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -16,7 +16,6 @@ var IntegrationMiddlewareChain = require('./middleware')
   .IntegrationMiddlewareChain;
 var Page = require('segmentio-facade').Page;
 var Track = require('segmentio-facade').Track;
-var after = require('@ndhoule/after');
 var bindAll = require('bind-all');
 var clone = require('@ndhoule/clone');
 var extend = require('extend');
@@ -54,6 +53,7 @@ function Analytics() {
   this._integrations = {};
   this._readied = false;
   this._timeout = 300;
+  this._callCount = 0;
   // XXX: BACKWARDS COMPATIBILITY
   this._user = user;
   this.log = debug('analytics.js');
@@ -187,10 +187,13 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(
 
   // make ready callback
   var integrationCount = keys(integrations).length;
-  var ready = after(integrationCount, function() {
-    self._readied = true;
-    self.emit('ready');
-  });
+  var ready = function() {
+    self._callCount++;
+    if (self._callCount >= integrationCount) {
+      self._readied = true;
+      self.emit('ready');
+    }
+  };
 
   // init if no integrations
   if (integrationCount <= 0) {
@@ -200,15 +203,24 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(
   // initialize integrations, passing ready
   // create a list of any integrations that did not initialize - this will be passed with all events for replay support:
   this.failedInitializations = [];
+  var initialPageSkipped = false;
   each(function(integration) {
     if (
       options.initialPageview &&
       integration.options.initialPageview === false
     ) {
-      integration.page = after(2, integration.page);
+      // We've assumed one initial pageview, so make sure we don't count the first page call.
+      var page = integration.page;
+      integration.page = function() {
+        if (initialPageSkipped) {
+          return page.apply(this, arguments);
+        }
+        return (initialPageSkipped = true);
+      };
     }
 
     integration.analytics = self;
+
     integration.once('ready', ready);
     try {
       metrics.increment('analytics_js.integration.invoke', {
@@ -225,6 +237,7 @@ Analytics.prototype.init = Analytics.prototype.initialize = function(
       self.failedInitializations.push(integrationName);
       self.log('Error initializing %s integration: %o', integrationName, e);
       // Mark integration as ready to prevent blocking of anyone listening to analytics.ready()
+
       integration.ready();
     }
   }, integrations);

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "homepage": "https://github.com/segmentio/analytics.js-core#readme",
   "dependencies": {
-    "@ndhoule/after": "^1.0.0",
     "@ndhoule/clone": "^1.0.0",
     "@ndhoule/defaults": "^2.0.1",
     "@ndhoule/each": "^2.0.1",

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -361,13 +361,11 @@ describe('Analytics', function() {
       analytics.initialize();
     });
 
-    // TODO: haven't figured out how to properly test this...
     it('should skip page call if assumepageview', function() {
       Test.prototype.page = sinon.spy();
       var options = { initialPageview: true };
       analytics.addIntegration(Test);
       analytics.initialize(settings, options);
-      // Should fail
       assert(Test.prototype.page.notCalled);
     });
   });

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -30,7 +30,8 @@ describe('Analytics', function() {
   beforeEach(function() {
     settings = {
       Test: {
-        key: 'key'
+        key: 'key',
+        initialPageview: false
       }
     };
 
@@ -358,6 +359,16 @@ describe('Analytics', function() {
         done();
       });
       analytics.initialize();
+    });
+
+    // TODO: haven't figured out how to properly test this...
+    it('should skip page call if assumepageview', function() {
+      Test.prototype.page = sinon.spy();
+      var options = { initialPageview: true };
+      analytics.addIntegration(Test);
+      analytics.initialize(settings, options);
+      // Should fail
+      assert(Test.prototype.page.notCalled);
     });
   });
 


### PR DESCRIPTION
For https://segment.atlassian.net/browse/LIB-1430

This PR removes the dependency on "after" which violated customer CSP with a new Function() call.