### PR TITLE
perf(json): use native json object

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -9,7 +9,6 @@ var clone = require('@ndhoule/clone');
 var cookie = require('component-cookie');
 var debug = require('debug')('analytics.js:cookie');
 var defaults = require('@ndhoule/defaults');
-var json = require('json3');
 var topDomain = require('@segment/top-domain');
 
 /**
@@ -72,7 +71,7 @@ Cookie.prototype.options = function(options) {
 
 Cookie.prototype.set = function(key, value) {
   try {
-    value = json.stringify(value);
+    value = window.JSON.stringify(value);
     cookie(key, value, clone(this._options));
     return true;
   } catch (e) {
@@ -90,7 +89,7 @@ Cookie.prototype.set = function(key, value) {
 Cookie.prototype.get = function(key) {
   try {
     var value = cookie(key);
-    value = value ? json.parse(value) : null;
+    value = value ? window.JSON.parse(value) : null;
     return value;
   } catch (e) {
     return null;

--- a/lib/normalize.js
+++ b/lib/normalize.js
@@ -11,7 +11,6 @@ var includes = require('@ndhoule/includes');
 var map = require('@ndhoule/map');
 var type = require('component-type');
 var uuid = require('uuid').v4;
-var json = require('json3');
 var md5 = require('spark-md5').hash;
 
 /**
@@ -79,7 +78,7 @@ function normalize(msg, list) {
   }, opts);
 
   // generate and attach a messageId to msg
-  msg.messageId = 'ajs-' + md5(json.stringify(msg) + uuid());
+  msg.messageId = 'ajs-' + md5(window.JSON.stringify(msg) + uuid());
 
   // cleanup
   delete msg.options;

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "inherits": "^2.0.1",
     "install": "^0.7.3",
     "is": "^3.1.0",
-    "json3": "^3.3.2",
     "new-date": "^1.0.0",
     "next-tick": "^0.2.2",
     "segmentio-facade": "^3.0.2",


### PR DESCRIPTION
Stop using deprecated json3 library and use instead builtin JSON object.

![image](https://user-images.githubusercontent.com/1561955/72909245-fc618800-3d36-11ea-94d6-ca2abf847e92.png)

**Is backwards compatible?** Well, Internet Explorer 6 & 7 support is dropped. Besides that, **yes.**