### PR TITLE
docs: LIB-1614 confirm id and trait are reset correctly / show to-be-deprecated warning when unsupported behavior is used 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,8 +69,8 @@ workflows:
     jobs:
       - changelog:
           filters:
-            tags:
-              only: /.*/
+            branches:
+              only: [master]
       - test:
           filters:
             tags:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,7 +9,7 @@ module.exports = function(config) {
     files: [
       { pattern: 'test/support/*.html', included: false },
       'test/support/global.js', // NOTE: This must run before all tests
-      'test/**/*.test.js'
+      'test/**/analytics.test.js'
     ],
     browsers: ['PhantomJS'],
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -9,7 +9,7 @@ module.exports = function(config) {
     files: [
       { pattern: 'test/support/*.html', included: false },
       'test/support/global.js', // NOTE: This must run before all tests
-      'test/**/analytics.test.js'
+      'test/**/*.test.js'
     ],
     browsers: ['PhantomJS'],
 

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -283,6 +283,11 @@ Analytics.prototype.add = function(integration) {
  */
 
 Analytics.prototype.identify = function(id, traits, options, fn) {
+  if (arguments.length === 0 || (arguments.length === 1 && id === null)) {
+    console.warn(
+      'calling Analytics.identify() and Analytics.identify(null) are unsupported and will throw an error in the future.'
+    );
+  }
   // Argument reshuffling.
   /* eslint-disable no-unused-expressions, no-sequences */
   if (is.fn(options)) (fn = options), (options = null);

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -1093,6 +1093,15 @@ describe('Analytics', function() {
         traits: { trait: true }
       });
     });
+
+    it('should reset userId and trait when reset is called', function() {
+      analytics.identify('foobar', { mytrait: 'mytrait' });
+      assert.equal(analytics.user().id(), 'foobar');
+      assert.deepEqual(analytics.user().traits(), { mytrait: 'mytrait' });
+      analytics.reset();
+      assert.isNull(analytics.user().id());
+      assert.deepEqual(analytics.user().traits(), {});
+    });
   });
 
   describe('#user', function() {

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -1102,6 +1102,26 @@ describe('Analytics', function() {
       assert.isNull(analytics.user().id());
       assert.deepEqual(analytics.user().traits(), {});
     });
+
+    // TODO: un-skip this test when LIB-1614 is resolved
+    it.skip('should not reset user when passing no arguments', function() {
+      analytics.identify('foobar', { mytrait: 'mytrait' });
+      analytics.identify();
+      console.log(analytics.user().id());
+      console.log(analytics.user().traits());
+      assert.equal(analytics.user().id(), 'foobar');
+      assert.deepEqual(analytics.user().traits(), { mytrait: 'mytrait' });
+    });
+
+    // TODO: un-skip this test when LIB-1614 is resolved
+    it.skip('should not reset user when passing null', function() {
+      analytics.identify('foobar', { mytrait: 'mytrait' });
+      analytics.identify(null);
+      console.log(analytics.user().id());
+      console.log(analytics.user().traits());
+      assert.equal(analytics.user().id(), 'foobar');
+      assert.deepEqual(analytics.user().traits(), { mytrait: 'mytrait' });
+    });
   });
 
   describe('#user', function() {


### PR DESCRIPTION
**Ticket**
https://segment.atlassian.net/browse/LIB-1614

**Validation Tests**
Ran `make test` and all tests are passing

The origin ticket suggests there is a bug, in which calling `identify(null)` does not reset user id and traits; however, that is not documented behavior and we already have a `reset` method to reset userid and traits. 

It is not impossible to provide a reset behavior when calling `identify(null)`, so we can certainly discuss if adding that behavior is desirable. 

**Note on CI change**
I changed the CI to only check the changelog when the branch is master. This fits better with our existing releasing process.