### PR TITLE
Only include version in package.json browserify

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,9 @@
-# v3.11.0 / 2020-01-27
 
-- v3.11.0
+# v3.11.3 / 2020-04-13
+
+- Transform package.json to strip excess in browserify
+
+# v3.11.0
 - feat: use SameSite=Lax by default (#128)
 
 # v3.10.1 / 2019-11-20

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-core",
   "author": "Segment <friends@segment.com>",
-  "version": "3.11.2",
+  "version": "3.11.3",
   "description": "The hassle-free way to integrate analytics into any web application.",
   "keywords": [
     "analytics",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "is": "^3.1.0",
     "new-date": "^1.0.0",
     "next-tick": "^0.2.2",
+    "package-json-versionify": "^1.0.4",
     "segmentio-facade": "^3.0.2",
     "spark-md5": "^2.0.2",
     "uuid": "^3.4.0"
@@ -122,5 +123,10 @@
     "commitizen": {
       "path": "cz-conventional-changelog"
     }
+  },
+  "browserify": {
+    "transform": [
+      "package-json-versionify"
+    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,6 +933,11 @@ browserify-istanbul@^2.0.0:
     minimatch "^3.0.0"
     through "^2.3.8"
 
+browserify-package-json@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/browserify-package-json/-/browserify-package-json-1.0.1.tgz#98dde8aa5c561fd6d3fe49bbaa102b74b396fdea"
+  integrity sha1-mN3oqlxWH9bT/km7qhArdLOW/eo=
+
 browserify-rsa@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/browserify-rsa/-/browserify-rsa-4.0.1.tgz#21e0abfaf6f2029cf2fafb133567a701d4135524"
@@ -5059,6 +5064,13 @@ pac-resolver@^3.0.0:
     ip "^1.1.5"
     netmask "^1.0.6"
     thunkify "^2.1.2"
+
+package-json-versionify@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/package-json-versionify/-/package-json-versionify-1.0.4.tgz#5860587a944873a6b7e6d26e8e51ffb22315bf17"
+  integrity sha1-WGBYepRIc6a35tJujlH/siMVvxc=
+  dependencies:
+    browserify-package-json "^1.0.0"
 
 package-json@^4.0.0:
   version "4.0.1"


### PR DESCRIPTION
This PR strips out all of the unnecessary info from package.json which gets exposed by browserify when we include it to pull the analytics.js-core version number.

This has been tested in staging - 
Before, it would have looked something like this:
![image](https://user-images.githubusercontent.com/2866515/79169424-45a6fe00-7da1-11ea-8be1-10bf88b76535.png)

After:
![image](https://user-images.githubusercontent.com/2866515/79169371-20b28b00-7da1-11ea-8901-30a02bbe44dd.png)

This is in reference to https://github.com/segmentio/analytics.js-core/issues/37 (LIB-146)