### PR TITLE
[LIBWEB-25] Tracking url hash on the page object

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 3.12.5 / 2020-04-23
+
+- adding a `hash` property to the current page information
+
 # 3.12.4 / 2020-04-23
 
 - test: add add/apply middleware stress test

--- a/lib/pageDefaults.js
+++ b/lib/pageDefaults.js
@@ -22,7 +22,8 @@ function pageDefaults() {
     referrer: document.referrer,
     search: location.search,
     title: document.title,
-    url: canonicalUrl(location.search)
+    url: canonicalUrl(location.search),
+    hash: location.hash
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-core",
   "author": "Segment <friends@segment.com>",
-  "version": "3.12.4",
+  "version": "3.12.5",
   "description": "The hassle-free way to integrate analytics into any web application.",
   "keywords": [
     "analytics",

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -619,7 +619,8 @@ describe('Analytics', function() {
         referrer: document.referrer,
         title: document.title,
         url: window.location.href,
-        search: window.location.search
+        search: window.location.search,
+        hash: window.location.hash
       };
       sinon.spy(analytics, '_invoke');
     });


### PR DESCRIPTION
## Description
https://segment.atlassian.net/browse/LIBWEB-25

Looks like in the docs we mentioned that we keep track of the hash, and now customers are asking why it is not tracked. Adding the `hash` key to the page object that is sent to Segment. 

![Screen Recording 2020-05-01 at 04 43 PM](https://user-images.githubusercontent.com/2992515/80849198-fd724300-8bca-11ea-9a55-238bb1cc0378.gif)


## Checklist

Please ensure the following are completed to help get your PR merged:

- [x] Thorough explanation of the issue/solution, and a link to the related issue
- [x] CI tests are passing
- [x] Unit tests were written for any new code
- [x] Code coverage is at least maintained, or increased.

## Respect earns Respect 👏

Please respect our Code of Conduct, in short:

- Using welcoming and inclusive language.
- Being respectful of differing viewpoints and experiences.
- Gracefully accepting constructive criticism.
- Focusing on what is best for the community.
- Showing empathy towards other community members.