### PR TITLE
docs: fix history

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-# 3.12.5 / 2020-05-04
+# 3.13.0 / 2020-05-04
 
 - refactor: remove third party dependency ndhoule/clone
 


### PR DESCRIPTION
## Description
I accidentally tagged the last version as `minor` instead of `patch`. This PR fixes the history to comply with what's deployed.

Testing not required because it's a no-op.