### PR TITLE
test now covers p/i/t/a/g

### DIFF
--- a/test-e2e/ajs.codecept.js
+++ b/test-e2e/ajs.codecept.js
@@ -10,6 +10,8 @@ Scenario(
     I.click('#page-home');
     I.click('#track-checkout-started');
     I.click('#identify-fathy');
+    I.click('#group');
+    I.click('#alias');
 
     await I.stopRecording(testID);
 

--- a/test-e2e/ajs.codecept.js
+++ b/test-e2e/ajs.codecept.js
@@ -24,3 +24,36 @@ Scenario(
     assert.equal(lsUserId, `"fathy"`);
   }
 ).injectDependencies({ testID: 'cookies-and-local-storage' });
+
+Scenario('Login as a different user', async (I, testID) => {
+  I.loadAJS({ local: true });
+
+  I.startRecording(testID);
+
+  I.click('#identify-spongebob');
+  let userId = await I.grabCookie('ajs_user_id');
+  assert.equal(userId.value, '%22spongebob%22');
+  let lsUserId = await I.executeScript(() => {
+    return localStorage.getItem('ajs_user_id');
+  });
+  assert.equal(lsUserId, `"spongebob"`);
+  I.click('#track-product-viewed');
+
+  I.click('#identify-fathy');
+  userId = await I.grabCookie('ajs_user_id');
+  assert.equal(userId.value, '%22fathy%22');
+  lsUserId = await I.executeScript(() => {
+    return localStorage.getItem('ajs_user_id');
+  });
+  assert.equal(lsUserId, `"fathy"`);
+  I.click('#track-product-viewed');
+
+  I.click('#reset');
+  userId = await I.grabCookie('ajs_user_id');
+  assert.strictEqual(userId, undefined);
+  lsUserId = await I.executeScript(() => {
+    return localStorage.getItem('ajs_user_id');
+  });
+  assert.strictEqual(lsUserId, null);
+  await I.stopRecording(testID);
+}).injectDependencies({ testID: 'login-as-different-user' });

--- a/test-e2e/reference/cookies-and-local-storage.har
+++ b/test-e2e/reference/cookies-and-local-storage.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "77d8a02c872d95c9974520c85a48ec7a",
+        "_id": "5ca1bb06fbe304605e7f0f8e0cf43539",
         "_order": 0,
         "cache": {},
         "request": {
@@ -34,7 +34,7 @@
           "postData": {
             "mimeType": "text/plain",
             "params": [],
-            "text": "{\"timestamp\":\"2020-06-22T18:38:11.510Z\",\"context\":{\"page\":{\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36\",\"locale\":\"en-US\",\"library\":{\"name\":\"analytics.js\",\"version\":\"3.13.5\"},\"campaign\":{}},\"integrations\":{},\"properties\":{\"name\":\"Home\",\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"category\":null,\"name\":\"Home\",\"messageId\":\"ajs-b93f4dabfb4b23811e7b25b6c8006882\",\"anonymousId\":\"bcda5d97-e6a4-43bc-96de-93725138f748\",\"type\":\"page\",\"writeKey\":\"WJq9vAlUO5l2255jMg7eEthbkDtq1svu\",\"userId\":null,\"sentAt\":\"2020-06-22T18:38:11.511Z\",\"_metadata\":{\"bundled\":[\"Segment.io\"],\"unbundled\":[]}}"
+            "text": "{\"timestamp\":\"2020-06-25T16:35:36.911Z\",\"context\":{\"page\":{\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36\",\"locale\":\"en-US\",\"library\":{\"name\":\"analytics.js\",\"version\":\"3.13.5\"},\"campaign\":{}},\"integrations\":{},\"properties\":{\"name\":\"Home\",\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"category\":null,\"name\":\"Home\",\"messageId\":\"ajs-a347eb788bd50d9b7cbebb924fd59df9\",\"anonymousId\":\"dc5253cd-0f81-42e1-ba12-907400f2b8b2\",\"type\":\"page\",\"writeKey\":\"WJq9vAlUO5l2255jMg7eEthbkDtq1svu\",\"userId\":null,\"sentAt\":\"2020-06-25T16:35:36.913Z\",\"_metadata\":{\"bundled\":[\"Segment.io\"],\"unbundled\":[]}}"
           },
           "queryString": [],
           "url": "https://api.segment.io/v1/p"
@@ -54,7 +54,7 @@
             },
             {
               "name": "date",
-              "value": "Mon, 22 Jun 2020 18:38:11 GMT"
+              "value": "Thu, 25 Jun 2020 16:35:37 GMT"
             },
             {
               "name": "access-control-allow-origin",
@@ -79,8 +79,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-06-22T18:38:11.519Z",
-        "time": 84,
+        "startedDateTime": "2020-06-25T16:35:36.921Z",
+        "time": 325,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -88,11 +88,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 84
+          "wait": 325
         }
       },
       {
-        "_id": "3e98e2657554c759c5c6af0ab3cddce9",
+        "_id": "ba7bd095f4a98a66676f5180474d424d",
         "_order": 0,
         "cache": {},
         "request": {
@@ -118,7 +118,7 @@
           "postData": {
             "mimeType": "text/plain",
             "params": [],
-            "text": "{\"timestamp\":\"2020-06-22T18:38:11.623Z\",\"integrations\":{},\"context\":{\"page\":{\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36\",\"locale\":\"en-US\",\"library\":{\"name\":\"analytics.js\",\"version\":\"3.13.5\"},\"campaign\":{}},\"event\":\"Checkout Started\",\"messageId\":\"ajs-ef1a29178658801ff63b424bf50b9ef2\",\"anonymousId\":\"bcda5d97-e6a4-43bc-96de-93725138f748\",\"type\":\"track\",\"writeKey\":\"WJq9vAlUO5l2255jMg7eEthbkDtq1svu\",\"userId\":null,\"sentAt\":\"2020-06-22T18:38:11.625Z\",\"_metadata\":{\"bundled\":[\"Segment.io\"],\"unbundled\":[]}}"
+            "text": "{\"timestamp\":\"2020-06-25T16:35:37.027Z\",\"integrations\":{},\"context\":{\"page\":{\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36\",\"locale\":\"en-US\",\"library\":{\"name\":\"analytics.js\",\"version\":\"3.13.5\"},\"campaign\":{}},\"event\":\"Checkout Started\",\"messageId\":\"ajs-27636a242918234ff2bbac0b229c0457\",\"anonymousId\":\"dc5253cd-0f81-42e1-ba12-907400f2b8b2\",\"type\":\"track\",\"writeKey\":\"WJq9vAlUO5l2255jMg7eEthbkDtq1svu\",\"userId\":null,\"sentAt\":\"2020-06-25T16:35:37.028Z\",\"_metadata\":{\"bundled\":[\"Segment.io\"],\"unbundled\":[]}}"
           },
           "queryString": [],
           "url": "https://api.segment.io/v1/t"
@@ -138,7 +138,7 @@
             },
             {
               "name": "date",
-              "value": "Mon, 22 Jun 2020 18:38:11 GMT"
+              "value": "Thu, 25 Jun 2020 16:35:37 GMT"
             },
             {
               "name": "access-control-allow-origin",
@@ -163,8 +163,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-06-22T18:38:11.629Z",
-        "time": 84,
+        "startedDateTime": "2020-06-25T16:35:37.032Z",
+        "time": 214,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -172,11 +172,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 84
+          "wait": 214
         }
       },
       {
-        "_id": "087dd8ae238b4cda0aaf5a00c79f148e",
+        "_id": "209579c89fcce605053caa379df73abf",
         "_order": 0,
         "cache": {},
         "request": {
@@ -202,7 +202,7 @@
           "postData": {
             "mimeType": "text/plain",
             "params": [],
-            "text": "{\"timestamp\":\"2020-06-22T18:38:11.739Z\",\"integrations\":{},\"context\":{\"page\":{\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36\",\"locale\":\"en-US\",\"library\":{\"name\":\"analytics.js\",\"version\":\"3.13.5\"},\"campaign\":{}},\"traits\":{},\"userId\":\"fathy\",\"messageId\":\"ajs-e978e0dd175512007f9b956d61488a8d\",\"anonymousId\":\"bcda5d97-e6a4-43bc-96de-93725138f748\",\"type\":\"identify\",\"writeKey\":\"WJq9vAlUO5l2255jMg7eEthbkDtq1svu\",\"sentAt\":\"2020-06-22T18:38:11.740Z\",\"_metadata\":{\"bundled\":[\"Segment.io\"],\"unbundled\":[]}}"
+            "text": "{\"timestamp\":\"2020-06-25T16:35:37.145Z\",\"integrations\":{},\"context\":{\"page\":{\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36\",\"locale\":\"en-US\",\"library\":{\"name\":\"analytics.js\",\"version\":\"3.13.5\"},\"campaign\":{}},\"traits\":{},\"userId\":\"fathy\",\"messageId\":\"ajs-42bd3ee6432f38094c2cd3fb20c4f3be\",\"anonymousId\":\"dc5253cd-0f81-42e1-ba12-907400f2b8b2\",\"type\":\"identify\",\"writeKey\":\"WJq9vAlUO5l2255jMg7eEthbkDtq1svu\",\"sentAt\":\"2020-06-25T16:35:37.147Z\",\"_metadata\":{\"bundled\":[\"Segment.io\"],\"unbundled\":[]}}"
           },
           "queryString": [],
           "url": "https://api.segment.io/v1/i"
@@ -222,7 +222,7 @@
             },
             {
               "name": "date",
-              "value": "Mon, 22 Jun 2020 18:38:11 GMT"
+              "value": "Thu, 25 Jun 2020 16:35:37 GMT"
             },
             {
               "name": "access-control-allow-origin",
@@ -247,8 +247,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-06-22T18:38:11.743Z",
-        "time": 86,
+        "startedDateTime": "2020-06-25T16:35:37.150Z",
+        "time": 116,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -256,7 +256,175 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 86
+          "wait": 116
+        }
+      },
+      {
+        "_id": "8a57f774df61478668defda359f27508",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 1184,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "referer",
+              "value": "http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36"
+            },
+            {
+              "name": "content-type",
+              "value": "text/plain"
+            }
+          ],
+          "headersSize": 312,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "text/plain",
+            "params": [],
+            "text": "{\"timestamp\":\"2020-06-25T16:35:37.258Z\",\"integrations\":{\"All\":true},\"context\":{\"page\":{\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36\",\"locale\":\"en-US\",\"library\":{\"name\":\"analytics.js\",\"version\":\"3.13.5\"},\"campaign\":{}},\"traits\":{\"address\":{\"city\":\"Vancouver\",\"country\":\"Canada\",\"postalCode\":\"V6b3E2\",\"state\":\"BC\",\"street\":\"21 Jump St\"},\"avatar\":\"does not exist\",\"description\":\"a fake group\",\"email\":\"email-me-not@domain.com\",\"employees\":3,\"id\":1,\"industry\":\"sw eng\",\"name\":\"libweb\",\"phone\":\"555-pizza\",\"website\":\"www.google.com\",\"plan\":\"business\"},\"groupId\":\"group name\",\"messageId\":\"ajs-382b0031f9ad9f3572180bae275a060a\",\"anonymousId\":\"dc5253cd-0f81-42e1-ba12-907400f2b8b2\",\"type\":\"group\",\"writeKey\":\"WJq9vAlUO5l2255jMg7eEthbkDtq1svu\",\"userId\":\"fathy\",\"sentAt\":\"2020-06-25T16:35:37.260Z\",\"_metadata\":{\"bundled\":[\"Segment.io\"],\"unbundled\":[]}}"
+          },
+          "queryString": [],
+          "url": "https://api.segment.io/v1/g"
+        },
+        "response": {
+          "bodySize": 21,
+          "content": {
+            "mimeType": "application/json",
+            "size": 21,
+            "text": "{\n  \"success\": true\n}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 25 Jun 2020 16:35:37 GMT"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "http://localhost:8000"
+            },
+            {
+              "name": "content-length",
+              "value": "21"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ],
+          "headersSize": 170,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-06-25T16:35:37.264Z",
+        "time": 85,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 85
+        }
+      },
+      {
+        "_id": "dd96977bb26d83c580ccaa1c1dc5a9be",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 860,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "referer",
+              "value": "http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36"
+            },
+            {
+              "name": "content-type",
+              "value": "text/plain"
+            }
+          ],
+          "headersSize": 312,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "text/plain",
+            "params": [],
+            "text": "{\"timestamp\":\"2020-06-25T16:35:37.376Z\",\"integrations\":{\"All\":true},\"context\":{\"page\":{\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36\",\"locale\":\"en-US\",\"library\":{\"name\":\"analytics.js\",\"version\":\"3.13.5\"},\"campaign\":{}},\"previousId\":\"previous id\",\"userId\":\"userId\",\"messageId\":\"ajs-02d2a2032a352b11fbb746471f8f8e1e\",\"anonymousId\":\"dc5253cd-0f81-42e1-ba12-907400f2b8b2\",\"type\":\"alias\",\"writeKey\":\"WJq9vAlUO5l2255jMg7eEthbkDtq1svu\",\"sentAt\":\"2020-06-25T16:35:37.379Z\",\"_metadata\":{\"bundled\":[\"Segment.io\"],\"unbundled\":[]}}"
+          },
+          "queryString": [],
+          "url": "https://api.segment.io/v1/a"
+        },
+        "response": {
+          "bodySize": 21,
+          "content": {
+            "mimeType": "application/json",
+            "size": 21,
+            "text": "{\n  \"success\": true\n}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 25 Jun 2020 16:35:37 GMT"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "http://localhost:8000"
+            },
+            {
+              "name": "content-length",
+              "value": "21"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ],
+          "headersSize": 170,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-06-25T16:35:37.382Z",
+        "time": 87,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 87
         }
       }
     ],

--- a/test-e2e/reference/cookies-and-local-storage.har
+++ b/test-e2e/reference/cookies-and-local-storage.har
@@ -8,7 +8,7 @@
     },
     "entries": [
       {
-        "_id": "5ca1bb06fbe304605e7f0f8e0cf43539",
+        "_id": "202717a71da0dce990beec6f6dc4f611",
         "_order": 0,
         "cache": {},
         "request": {
@@ -34,7 +34,7 @@
           "postData": {
             "mimeType": "text/plain",
             "params": [],
-            "text": "{\"timestamp\":\"2020-06-25T16:35:36.911Z\",\"context\":{\"page\":{\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36\",\"locale\":\"en-US\",\"library\":{\"name\":\"analytics.js\",\"version\":\"3.13.5\"},\"campaign\":{}},\"integrations\":{},\"properties\":{\"name\":\"Home\",\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"category\":null,\"name\":\"Home\",\"messageId\":\"ajs-a347eb788bd50d9b7cbebb924fd59df9\",\"anonymousId\":\"dc5253cd-0f81-42e1-ba12-907400f2b8b2\",\"type\":\"page\",\"writeKey\":\"WJq9vAlUO5l2255jMg7eEthbkDtq1svu\",\"userId\":null,\"sentAt\":\"2020-06-25T16:35:36.913Z\",\"_metadata\":{\"bundled\":[\"Segment.io\"],\"unbundled\":[]}}"
+            "text": "{\"timestamp\":\"2020-06-25T21:00:02.346Z\",\"context\":{\"page\":{\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36\",\"locale\":\"en-US\",\"library\":{\"name\":\"analytics.js\",\"version\":\"3.13.5\"},\"campaign\":{}},\"integrations\":{},\"properties\":{\"name\":\"Home\",\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"category\":null,\"name\":\"Home\",\"messageId\":\"ajs-98bde5ff6e37234a5c09cce9e8f732cf\",\"anonymousId\":\"4a4dc2d0-1597-4d57-8a12-0d8fcac981c4\",\"type\":\"page\",\"writeKey\":\"WJq9vAlUO5l2255jMg7eEthbkDtq1svu\",\"userId\":null,\"sentAt\":\"2020-06-25T21:00:02.348Z\",\"_metadata\":{\"bundled\":[\"Segment.io\"],\"unbundled\":[]}}"
           },
           "queryString": [],
           "url": "https://api.segment.io/v1/p"
@@ -54,7 +54,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 25 Jun 2020 16:35:37 GMT"
+              "value": "Thu, 25 Jun 2020 21:00:02 GMT"
             },
             {
               "name": "access-control-allow-origin",
@@ -79,8 +79,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-06-25T16:35:36.921Z",
-        "time": 325,
+        "startedDateTime": "2020-06-25T21:00:02.357Z",
+        "time": 81,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -88,11 +88,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 325
+          "wait": 81
         }
       },
       {
-        "_id": "ba7bd095f4a98a66676f5180474d424d",
+        "_id": "ce9993aa34dc95d1a41ae44ae9b31aab",
         "_order": 0,
         "cache": {},
         "request": {
@@ -118,7 +118,7 @@
           "postData": {
             "mimeType": "text/plain",
             "params": [],
-            "text": "{\"timestamp\":\"2020-06-25T16:35:37.027Z\",\"integrations\":{},\"context\":{\"page\":{\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36\",\"locale\":\"en-US\",\"library\":{\"name\":\"analytics.js\",\"version\":\"3.13.5\"},\"campaign\":{}},\"event\":\"Checkout Started\",\"messageId\":\"ajs-27636a242918234ff2bbac0b229c0457\",\"anonymousId\":\"dc5253cd-0f81-42e1-ba12-907400f2b8b2\",\"type\":\"track\",\"writeKey\":\"WJq9vAlUO5l2255jMg7eEthbkDtq1svu\",\"userId\":null,\"sentAt\":\"2020-06-25T16:35:37.028Z\",\"_metadata\":{\"bundled\":[\"Segment.io\"],\"unbundled\":[]}}"
+            "text": "{\"timestamp\":\"2020-06-25T21:00:02.458Z\",\"integrations\":{},\"context\":{\"page\":{\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36\",\"locale\":\"en-US\",\"library\":{\"name\":\"analytics.js\",\"version\":\"3.13.5\"},\"campaign\":{}},\"event\":\"Checkout Started\",\"messageId\":\"ajs-9784604e3c0f25fec5501e36ffff71a9\",\"anonymousId\":\"4a4dc2d0-1597-4d57-8a12-0d8fcac981c4\",\"type\":\"track\",\"writeKey\":\"WJq9vAlUO5l2255jMg7eEthbkDtq1svu\",\"userId\":null,\"sentAt\":\"2020-06-25T21:00:02.460Z\",\"_metadata\":{\"bundled\":[\"Segment.io\"],\"unbundled\":[]}}"
           },
           "queryString": [],
           "url": "https://api.segment.io/v1/t"
@@ -138,7 +138,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 25 Jun 2020 16:35:37 GMT"
+              "value": "Thu, 25 Jun 2020 21:00:02 GMT"
             },
             {
               "name": "access-control-allow-origin",
@@ -163,8 +163,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-06-25T16:35:37.032Z",
-        "time": 214,
+        "startedDateTime": "2020-06-25T21:00:02.464Z",
+        "time": 81,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -172,11 +172,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 214
+          "wait": 81
         }
       },
       {
-        "_id": "209579c89fcce605053caa379df73abf",
+        "_id": "eebbc8bccd7435de7fc170ff6fc082d6",
         "_order": 0,
         "cache": {},
         "request": {
@@ -202,7 +202,7 @@
           "postData": {
             "mimeType": "text/plain",
             "params": [],
-            "text": "{\"timestamp\":\"2020-06-25T16:35:37.145Z\",\"integrations\":{},\"context\":{\"page\":{\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36\",\"locale\":\"en-US\",\"library\":{\"name\":\"analytics.js\",\"version\":\"3.13.5\"},\"campaign\":{}},\"traits\":{},\"userId\":\"fathy\",\"messageId\":\"ajs-42bd3ee6432f38094c2cd3fb20c4f3be\",\"anonymousId\":\"dc5253cd-0f81-42e1-ba12-907400f2b8b2\",\"type\":\"identify\",\"writeKey\":\"WJq9vAlUO5l2255jMg7eEthbkDtq1svu\",\"sentAt\":\"2020-06-25T16:35:37.147Z\",\"_metadata\":{\"bundled\":[\"Segment.io\"],\"unbundled\":[]}}"
+            "text": "{\"timestamp\":\"2020-06-25T21:00:02.576Z\",\"integrations\":{},\"context\":{\"page\":{\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36\",\"locale\":\"en-US\",\"library\":{\"name\":\"analytics.js\",\"version\":\"3.13.5\"},\"campaign\":{}},\"traits\":{},\"userId\":\"fathy\",\"messageId\":\"ajs-a62c780f7b795d5c236421d355cd1169\",\"anonymousId\":\"4a4dc2d0-1597-4d57-8a12-0d8fcac981c4\",\"type\":\"identify\",\"writeKey\":\"WJq9vAlUO5l2255jMg7eEthbkDtq1svu\",\"sentAt\":\"2020-06-25T21:00:02.577Z\",\"_metadata\":{\"bundled\":[\"Segment.io\"],\"unbundled\":[]}}"
           },
           "queryString": [],
           "url": "https://api.segment.io/v1/i"
@@ -222,7 +222,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 25 Jun 2020 16:35:37 GMT"
+              "value": "Thu, 25 Jun 2020 21:00:02 GMT"
             },
             {
               "name": "access-control-allow-origin",
@@ -247,8 +247,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-06-25T16:35:37.150Z",
-        "time": 116,
+        "startedDateTime": "2020-06-25T21:00:02.580Z",
+        "time": 84,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -256,11 +256,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 116
+          "wait": 84
         }
       },
       {
-        "_id": "8a57f774df61478668defda359f27508",
+        "_id": "b76bab56b19b4bc04daa923e6925e706",
         "_order": 0,
         "cache": {},
         "request": {
@@ -286,7 +286,7 @@
           "postData": {
             "mimeType": "text/plain",
             "params": [],
-            "text": "{\"timestamp\":\"2020-06-25T16:35:37.258Z\",\"integrations\":{\"All\":true},\"context\":{\"page\":{\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36\",\"locale\":\"en-US\",\"library\":{\"name\":\"analytics.js\",\"version\":\"3.13.5\"},\"campaign\":{}},\"traits\":{\"address\":{\"city\":\"Vancouver\",\"country\":\"Canada\",\"postalCode\":\"V6b3E2\",\"state\":\"BC\",\"street\":\"21 Jump St\"},\"avatar\":\"does not exist\",\"description\":\"a fake group\",\"email\":\"email-me-not@domain.com\",\"employees\":3,\"id\":1,\"industry\":\"sw eng\",\"name\":\"libweb\",\"phone\":\"555-pizza\",\"website\":\"www.google.com\",\"plan\":\"business\"},\"groupId\":\"group name\",\"messageId\":\"ajs-382b0031f9ad9f3572180bae275a060a\",\"anonymousId\":\"dc5253cd-0f81-42e1-ba12-907400f2b8b2\",\"type\":\"group\",\"writeKey\":\"WJq9vAlUO5l2255jMg7eEthbkDtq1svu\",\"userId\":\"fathy\",\"sentAt\":\"2020-06-25T16:35:37.260Z\",\"_metadata\":{\"bundled\":[\"Segment.io\"],\"unbundled\":[]}}"
+            "text": "{\"timestamp\":\"2020-06-25T21:00:02.692Z\",\"integrations\":{\"All\":true},\"context\":{\"page\":{\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36\",\"locale\":\"en-US\",\"library\":{\"name\":\"analytics.js\",\"version\":\"3.13.5\"},\"campaign\":{}},\"traits\":{\"address\":{\"city\":\"Vancouver\",\"country\":\"Canada\",\"postalCode\":\"V6b3E2\",\"state\":\"BC\",\"street\":\"21 Jump St\"},\"avatar\":\"does not exist\",\"description\":\"a fake group\",\"email\":\"email-me-not@domain.com\",\"employees\":3,\"id\":1,\"industry\":\"sw eng\",\"name\":\"libweb\",\"phone\":\"555-pizza\",\"website\":\"www.google.com\",\"plan\":\"business\"},\"groupId\":\"group name\",\"messageId\":\"ajs-28a2ca83dbdf489f60a1f65e1dcb51b3\",\"anonymousId\":\"4a4dc2d0-1597-4d57-8a12-0d8fcac981c4\",\"type\":\"group\",\"writeKey\":\"WJq9vAlUO5l2255jMg7eEthbkDtq1svu\",\"userId\":\"fathy\",\"sentAt\":\"2020-06-25T21:00:02.693Z\",\"_metadata\":{\"bundled\":[\"Segment.io\"],\"unbundled\":[]}}"
           },
           "queryString": [],
           "url": "https://api.segment.io/v1/g"
@@ -306,7 +306,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 25 Jun 2020 16:35:37 GMT"
+              "value": "Thu, 25 Jun 2020 21:00:02 GMT"
             },
             {
               "name": "access-control-allow-origin",
@@ -331,8 +331,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-06-25T16:35:37.264Z",
-        "time": 85,
+        "startedDateTime": "2020-06-25T21:00:02.696Z",
+        "time": 81,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -340,11 +340,11 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 85
+          "wait": 81
         }
       },
       {
-        "_id": "dd96977bb26d83c580ccaa1c1dc5a9be",
+        "_id": "62b6076c4d9c54e653a93411b509ed47",
         "_order": 0,
         "cache": {},
         "request": {
@@ -370,7 +370,7 @@
           "postData": {
             "mimeType": "text/plain",
             "params": [],
-            "text": "{\"timestamp\":\"2020-06-25T16:35:37.376Z\",\"integrations\":{\"All\":true},\"context\":{\"page\":{\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36\",\"locale\":\"en-US\",\"library\":{\"name\":\"analytics.js\",\"version\":\"3.13.5\"},\"campaign\":{}},\"previousId\":\"previous id\",\"userId\":\"userId\",\"messageId\":\"ajs-02d2a2032a352b11fbb746471f8f8e1e\",\"anonymousId\":\"dc5253cd-0f81-42e1-ba12-907400f2b8b2\",\"type\":\"alias\",\"writeKey\":\"WJq9vAlUO5l2255jMg7eEthbkDtq1svu\",\"sentAt\":\"2020-06-25T16:35:37.379Z\",\"_metadata\":{\"bundled\":[\"Segment.io\"],\"unbundled\":[]}}"
+            "text": "{\"timestamp\":\"2020-06-25T21:00:02.808Z\",\"integrations\":{\"All\":true},\"context\":{\"page\":{\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36\",\"locale\":\"en-US\",\"library\":{\"name\":\"analytics.js\",\"version\":\"3.13.5\"},\"campaign\":{}},\"previousId\":\"previous id\",\"userId\":\"userId\",\"messageId\":\"ajs-6d694f3cfc91a05eb5bbcabcee0042a1\",\"anonymousId\":\"4a4dc2d0-1597-4d57-8a12-0d8fcac981c4\",\"type\":\"alias\",\"writeKey\":\"WJq9vAlUO5l2255jMg7eEthbkDtq1svu\",\"sentAt\":\"2020-06-25T21:00:02.810Z\",\"_metadata\":{\"bundled\":[\"Segment.io\"],\"unbundled\":[]}}"
           },
           "queryString": [],
           "url": "https://api.segment.io/v1/a"
@@ -390,7 +390,7 @@
             },
             {
               "name": "date",
-              "value": "Thu, 25 Jun 2020 16:35:37 GMT"
+              "value": "Thu, 25 Jun 2020 21:00:02 GMT"
             },
             {
               "name": "access-control-allow-origin",
@@ -415,8 +415,8 @@
           "status": 200,
           "statusText": "OK"
         },
-        "startedDateTime": "2020-06-25T16:35:37.382Z",
-        "time": 87,
+        "startedDateTime": "2020-06-25T21:00:02.813Z",
+        "time": 85,
         "timings": {
           "blocked": -1,
           "connect": -1,
@@ -424,7 +424,7 @@
           "receive": 0,
           "send": 0,
           "ssl": -1,
-          "wait": 87
+          "wait": 85
         }
       }
     ],

--- a/test-e2e/reference/login-as-different-user.har
+++ b/test-e2e/reference/login-as-different-user.har
@@ -1,0 +1,350 @@
+{
+  "log": {
+    "_recordingName": "login-as-different-user",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "4f1f8ba74cd18b265b90ca175df43823",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 865,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "referer",
+              "value": "http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36"
+            },
+            {
+              "name": "content-type",
+              "value": "text/plain"
+            }
+          ],
+          "headersSize": 312,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "text/plain",
+            "params": [],
+            "text": "{\"timestamp\":\"2020-06-25T21:00:04.685Z\",\"integrations\":{},\"context\":{\"page\":{\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36\",\"locale\":\"en-US\",\"library\":{\"name\":\"analytics.js\",\"version\":\"3.13.5\"},\"campaign\":{}},\"traits\":{\"lastname\":\"squarepants\"},\"userId\":\"spongebob\",\"messageId\":\"ajs-2289ad0d23ab5f5aaac9ad0c01b00d3b\",\"anonymousId\":\"b7580f23-4ed8-448a-a4c9-90479010cd73\",\"type\":\"identify\",\"writeKey\":\"WJq9vAlUO5l2255jMg7eEthbkDtq1svu\",\"sentAt\":\"2020-06-25T21:00:04.687Z\",\"_metadata\":{\"bundled\":[\"Segment.io\"],\"unbundled\":[]}}"
+          },
+          "queryString": [],
+          "url": "https://api.segment.io/v1/i"
+        },
+        "response": {
+          "bodySize": 21,
+          "content": {
+            "mimeType": "application/json",
+            "size": 21,
+            "text": "{\n  \"success\": true\n}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 25 Jun 2020 21:00:04 GMT"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "http://localhost:8000"
+            },
+            {
+              "name": "content-length",
+              "value": "21"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ],
+          "headersSize": 170,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-06-25T21:00:04.689Z",
+        "time": 130,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 130
+        }
+      },
+      {
+        "_id": "3d5ab4359ea6176df95e9553d34433b7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 851,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "referer",
+              "value": "http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36"
+            },
+            {
+              "name": "content-type",
+              "value": "text/plain"
+            }
+          ],
+          "headersSize": 312,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "text/plain",
+            "params": [],
+            "text": "{\"timestamp\":\"2020-06-25T21:00:04.802Z\",\"integrations\":{},\"context\":{\"page\":{\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36\",\"locale\":\"en-US\",\"library\":{\"name\":\"analytics.js\",\"version\":\"3.13.5\"},\"campaign\":{}},\"event\":\"Product Viewed\",\"messageId\":\"ajs-a4146db98f4f3ab56230b588343193f9\",\"anonymousId\":\"b7580f23-4ed8-448a-a4c9-90479010cd73\",\"type\":\"track\",\"writeKey\":\"WJq9vAlUO5l2255jMg7eEthbkDtq1svu\",\"userId\":\"spongebob\",\"sentAt\":\"2020-06-25T21:00:04.804Z\",\"_metadata\":{\"bundled\":[\"Segment.io\"],\"unbundled\":[]}}"
+          },
+          "queryString": [],
+          "url": "https://api.segment.io/v1/t"
+        },
+        "response": {
+          "bodySize": 21,
+          "content": {
+            "mimeType": "application/json",
+            "size": 21,
+            "text": "{\n  \"success\": true\n}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 25 Jun 2020 21:00:04 GMT"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "http://localhost:8000"
+            },
+            {
+              "name": "content-length",
+              "value": "21"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ],
+          "headersSize": 170,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-06-25T21:00:04.807Z",
+        "time": 83,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 83
+        }
+      },
+      {
+        "_id": "901a3328124bce064997ccfc217e75cf",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 837,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "referer",
+              "value": "http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36"
+            },
+            {
+              "name": "content-type",
+              "value": "text/plain"
+            }
+          ],
+          "headersSize": 312,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "text/plain",
+            "params": [],
+            "text": "{\"timestamp\":\"2020-06-25T21:00:04.919Z\",\"integrations\":{},\"context\":{\"page\":{\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36\",\"locale\":\"en-US\",\"library\":{\"name\":\"analytics.js\",\"version\":\"3.13.5\"},\"campaign\":{}},\"traits\":{},\"userId\":\"fathy\",\"messageId\":\"ajs-94455e6285e3fc7b73dabfff7dd0d5bd\",\"anonymousId\":\"273b8227-27dc-4f7f-8c8c-3a62df7908da\",\"type\":\"identify\",\"writeKey\":\"WJq9vAlUO5l2255jMg7eEthbkDtq1svu\",\"sentAt\":\"2020-06-25T21:00:04.920Z\",\"_metadata\":{\"bundled\":[\"Segment.io\"],\"unbundled\":[]}}"
+          },
+          "queryString": [],
+          "url": "https://api.segment.io/v1/i"
+        },
+        "response": {
+          "bodySize": 21,
+          "content": {
+            "mimeType": "application/json",
+            "size": 21,
+            "text": "{\n  \"success\": true\n}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 25 Jun 2020 21:00:04 GMT"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "http://localhost:8000"
+            },
+            {
+              "name": "content-length",
+              "value": "21"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ],
+          "headersSize": 170,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-06-25T21:00:04.923Z",
+        "time": 84,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 84
+        }
+      },
+      {
+        "_id": "57b2971e30426f6b21c20acae0f60faf",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 847,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "referer",
+              "value": "http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000"
+            },
+            {
+              "name": "user-agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36"
+            },
+            {
+              "name": "content-type",
+              "value": "text/plain"
+            }
+          ],
+          "headersSize": 312,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "text/plain",
+            "params": [],
+            "text": "{\"timestamp\":\"2020-06-25T21:00:05.035Z\",\"integrations\":{},\"context\":{\"page\":{\"path\":\"/\",\"referrer\":\"http://localhost:8000/\",\"search\":\"?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\",\"title\":\"AJS tester\",\"url\":\"http://localhost:8000/?writeKey=WJq9vAlUO5l2255jMg7eEthbkDtq1svu&cdnHost=localhost%3A8000\"},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/83.0.4103.0 Safari/537.36\",\"locale\":\"en-US\",\"library\":{\"name\":\"analytics.js\",\"version\":\"3.13.5\"},\"campaign\":{}},\"event\":\"Product Viewed\",\"messageId\":\"ajs-395b9090d49dff0ae4f620641ce99a29\",\"anonymousId\":\"273b8227-27dc-4f7f-8c8c-3a62df7908da\",\"type\":\"track\",\"writeKey\":\"WJq9vAlUO5l2255jMg7eEthbkDtq1svu\",\"userId\":\"fathy\",\"sentAt\":\"2020-06-25T21:00:05.036Z\",\"_metadata\":{\"bundled\":[\"Segment.io\"],\"unbundled\":[]}}"
+          },
+          "queryString": [],
+          "url": "https://api.segment.io/v1/t"
+        },
+        "response": {
+          "bodySize": 21,
+          "content": {
+            "mimeType": "application/json",
+            "size": 21,
+            "text": "{\n  \"success\": true\n}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "status",
+              "value": "200"
+            },
+            {
+              "name": "date",
+              "value": "Thu, 25 Jun 2020 21:00:05 GMT"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "http://localhost:8000"
+            },
+            {
+              "name": "content-length",
+              "value": "21"
+            },
+            {
+              "name": "vary",
+              "value": "Origin"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ],
+          "headersSize": 170,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-06-25T21:00:05.039Z",
+        "time": 84,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 84
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/test-e2e/static/index.html
+++ b/test-e2e/static/index.html
@@ -25,7 +25,7 @@
     <button id='page-contact' onclick="analytics.page('Contact')">Page: Contact</button>
     <br />
     <button id='identify-fathy' onclick="analytics.identify('fathy')">Identify: fathy</button>
-    <button id='identify-spongebob' onclick="analytics.identify('spongebob')">
+    <button id='identify-spongebob' onclick="analytics.identify('spongebob', {'lastname':'squarepants'})">
       Identify: spongebob
     </button>
     <button
@@ -69,6 +69,7 @@
       Alias
     </button>
 
+    <button id='reset' onclick="analytics.reset()">Reset</button>
     <br />
 
     <script>

--- a/test-e2e/static/index.html
+++ b/test-e2e/static/index.html
@@ -41,7 +41,6 @@
             'street': '21 Jump St'
           },
           'avatar': 'does not exist',
-          'createdAt': new Date(),
           'description': 'a fake group',
           'email': 'email-me-not@domain.com',
           'employees': 3,


### PR DESCRIPTION
# Description
This PR updated the tests to cover page / identify / track / alias / group calls, as well as adding another test scenario. 

# Testing
Testing completed successfully by running `make test-e2e` and see that tests passed.

```
$ make test-e2e
yarn
yarn install v1.22.4
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.42s.
(pkill SIGTERM ajs-test-e2e-dev-server) || true
yarn ts-node ./test-e2e/devServer.ts &
rm -rf ./test-e2e/output
rm -rf ./test-e2e/staging
mkdir ./test-e2e/staging
yarn wait-on http://localhost:8000 && npx codeceptjs run --steps
yarn run v1.22.4
yarn run v1.22.4
$ /Users/kinglong.tse/dev/src/github.com/segmentio/analytics.js-core/node_modules/.bin/ts-node ./test-e2e/devServer.ts
$ /Users/kinglong.tse/dev/src/github.com/segmentio/analytics.js-core/node_modules/.bin/wait-on http://localhost:8000
Found analytics.js locally at /Users/kinglong.tse/dev/src/github.com/segmentio/analytics.js-core/test-e2e/static/analytics.js
test-e2e dev server listening at http://localhost:8000
✨  Done in 2.13s.
creating output directory: /Users/kinglong.tse/dev/src/github.com/segmentio/analytics.js-core/test-e2e/output
CodeceptJS v2.6.5
Using test root "/Users/kinglong.tse/dev/src/github.com/segmentio/analytics.js-core"

AJS Bundle --
  User id is stored in cookies and local storage
    I: loadAJS
      I am on page "http://localhost:8000"
      I fill field "cdnHost", "localhost:8000"
      I fill field "writeKey", "WJq9vAlUO5l2255jMg7eEthbkDtq1svu"
      I click "Load"
      I wait for text "loaded", 5, "#status-msg"
    I: startRecording
      I start mocking
      I mock server server => {
        server.any('https://api.segment.io/*').recordingName(testID);
      }
    I click "#page-home"
    I click "#track-checkout-started"
    I click "#identify-fathy"
    I click "#group"
    I click "#alias"
    I: stopRecording
      I stop mocking
    I grab cookie "ajs_user_id"
    I execute script () => {
      return localStorage.getItem('ajs_user_id');
    }
  ✔ OK in 2181ms

  Login as a different user
    I: loadAJS
      I am on page "http://localhost:8000"
      I fill field "cdnHost", "localhost:8000"
      I fill field "writeKey", "WJq9vAlUO5l2255jMg7eEthbkDtq1svu"
      I click "Load"
      I wait for text "loaded", 5, "#status-msg"
    I: startRecording
      I start mocking
      I mock server server => {
        server.any('https://api.segment.io/*').recordingName(testID);
      }
    I click "#identify-spongebob"
    I grab cookie "ajs_user_id"
    I execute script () => {
    return localStorage.getItem('ajs_user_id');
  }
    I click "#track-product-viewed"
    I click "#identify-fathy"
    I grab cookie "ajs_user_id"
    I execute script () => {
    return localStorage.getItem('ajs_user_id');
  }
    I click "#track-product-viewed"
    I click "#reset"
    I grab cookie "ajs_user_id"
    I execute script () => {
    return localStorage.getItem('ajs_user_id');
  }
    I: stopRecording
      I stop mocking
  ✔ OK in 1882ms


  OK  | 2 passed   // 5s
(pkill SIGTERM ajs-test-e2e-dev-server)
SIGTERM received. Exiting.
TS_NODE_COMPILER_OPTIONS='{"esModuleInterop":true}' yarn mocha -r ts-node/register ./test-e2e/requests.test.ts
✨  Done in 8.20s.
yarn run v1.22.4
$ /Users/kinglong.tse/dev/src/github.com/segmentio/analytics.js-core/node_modules/.bin/mocha -r ts-node/register ./test-e2e/requests.test.ts


  compare har files against reference
    ✓ cookies-and-local-storage.har
    ✓ login-as-different-user.har


  2 passing (9ms)

✨  Done in 1.53s.
```

# Releasing
New version is not required because this only updates the tests