### PR TITLE
Convert group, memory, metrics, normalize, pageDefaults and store to .ts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,14 +20,13 @@ For change control purposes, use the following pattern:
 <!-- Update the HISTORY.md file if we need to generate a new version of AJS for your changes.
 
 If not, just add the following line with an explanation:
-Release not necessary because <verbose explantaion - for example 'it's a dev-only change'>.
+New version is not required because <verbose explantaion - for example 'it's a dev-only change'>.
 -->
 
 ## Checklist
 
 <!--
 Make sure you complete the following checklist to help get your PR merged:-->
-
 
 - [ ] Thorough explanation of the issue/solution, and a link to the related issue
 - [ ] CI tests are passing

--- a/lib/group.ts
+++ b/lib/group.ts
@@ -1,5 +1,7 @@
 'use strict';
 
+import { InitOptions } from './types';
+
 /*
  * Module dependencies.
  */
@@ -25,11 +27,9 @@ Group.defaults = {
 
 /**
  * Initialize a new `Group` with `options`.
- *
- * @param {Object} options
  */
 
-function Group(options) {
+function Group(options?: InitOptions) {
   this.defaults = Group.defaults;
   this.debug = debug;
   Entity.call(this, options);

--- a/lib/memory.ts
+++ b/lib/memory.ts
@@ -29,36 +29,27 @@ function Memory() {
 
 /**
  * Set a `key` and `value`.
- *
- * @param {String} key
- * @param {Mixed} value
- * @return {Boolean}
  */
 
-Memory.prototype.set = function(key, value) {
+Memory.prototype.set = function(key: string, value: unknown): boolean {
   this.store[key] = clone(value);
   return true;
 };
 
 /**
  * Get a `key`.
- *
- * @param {String} key
  */
 
-Memory.prototype.get = function(key) {
+Memory.prototype.get = function(key: string): unknown | undefined {
   if (!has.call(this.store, key)) return;
   return clone(this.store[key]);
 };
 
 /**
  * Remove a `key`.
- *
- * @param {String} key
- * @return {Boolean}
  */
 
-Memory.prototype.remove = function(key) {
+Memory.prototype.remove = function(key: string): boolean {
   delete this.store[key];
   return true;
 };

--- a/lib/metrics.ts
+++ b/lib/metrics.ts
@@ -1,23 +1,20 @@
 'use strict';
 
+import { MetricsOptions } from './types';
+
 var bindAll = require('bind-all');
 var send = require('@segment/send-json');
 var debug = require('debug')('analytics.js:metrics');
 
-function Metrics(options) {
+function Metrics(options?: MetricsOptions) {
   this.options(options);
 }
 
 /**
  * Set the metrics options.
- *
- * @param {Object} options
- *   @field {String} host
- *   @field {Number} sampleRate
- *   @field {Number} flushTimer
  */
 
-Metrics.prototype.options = function(options) {
+Metrics.prototype.options = function(options: MetricsOptions) {
   options = options || {};
 
   this.host = options.host || 'api.segment.io/v1';
@@ -37,11 +34,8 @@ Metrics.prototype.options = function(options) {
 
 /**
  * Increments the counter identified by name and tags by one.
- *
- * @param {String} metric Name of the metric to increment.
- * @param {Object} tags Dimensions associated with the metric.
  */
-Metrics.prototype.increment = function(metric, tags) {
+Metrics.prototype.increment = function(metric: string, tags: object) {
   if (Math.random() > this.sampleRate) {
     return;
   }

--- a/lib/normalize.ts
+++ b/lib/normalize.ts
@@ -1,5 +1,7 @@
 'use strict';
 
+import { Message } from './types';
+
 /**
  * Module Dependencies.
  */
@@ -33,25 +35,31 @@ var toplevel = ['integrations', 'anonymousId', 'timestamp', 'context'];
 
 /**
  * Normalize `msg` based on integrations `list`.
- *
- * @param {Object} msg
- * @param {Array} list
- * @return {Function}
  */
 
-function normalize(msg, list) {
+interface NormalizedMessage {
+  integrations?: {
+    [key: string]: string;
+  };
+  context?: unknown;
+}
+
+function normalize(msg: Message, list: Array<any>): NormalizedMessage {
   var lower = map(function(s) {
     return s.toLowerCase();
   }, list);
-  var opts = msg.options || {};
+  var opts: Message = msg.options || {};
   var integrations = opts.integrations || {};
   var providers = opts.providers || {};
   var context = opts.context || {};
-  var ret = {};
+  var ret: {
+    integrations?: { [key: string]: string };
+    context?: unknown;
+  } = {};
   debug('<-', msg);
 
   // integrations.
-  each(function(value, key) {
+  each(function(value: string, key: string) {
     if (!integration(key)) return;
     if (!has.call(integrations, key)) integrations[key] = value;
     delete opts[key];
@@ -59,7 +67,7 @@ function normalize(msg, list) {
 
   // providers.
   delete opts.providers;
-  each(function(value, key) {
+  each(function(value: string, key: string) {
     if (!integration(key)) return;
     if (type(integrations[key]) === 'object') return;
     if (has.call(integrations, key) && typeof providers[key] === 'boolean')
@@ -69,7 +77,7 @@ function normalize(msg, list) {
 
   // move all toplevel options to msg
   // and the rest to context.
-  each(function(value, key) {
+  each(function(_value: any, key: string | number) {
     if (includes(key, toplevel)) {
       ret[key] = opts[key];
     } else {
@@ -88,7 +96,7 @@ function normalize(msg, list) {
   debug('->', ret);
   return ret;
 
-  function integration(name) {
+  function integration(name: string) {
     return !!(
       includes(name, list) ||
       name.toLowerCase() === 'all' ||

--- a/lib/pageDefaults.ts
+++ b/lib/pageDefaults.ts
@@ -1,5 +1,7 @@
 'use strict';
 
+import { PageDefaults } from './types';
+
 /*
  * Module dependencies.
  */
@@ -12,11 +14,9 @@ var url = require('component-url');
  * Return a default `options.context.page` object.
  *
  * https://segment.com/docs/spec/page/#properties
- *
- * @return {Object}
  */
 
-function pageDefaults() {
+function pageDefaults(): PageDefaults {
   return {
     path: canonicalPath(),
     referrer: document.referrer,
@@ -28,11 +28,9 @@ function pageDefaults() {
 
 /**
  * Return the canonical path for the page.
- *
- * @return {string}
  */
 
-function canonicalPath() {
+function canonicalPath(): string {
   var canon = canonical();
   if (!canon) return window.location.pathname;
   var parsed = url.parse(canon);
@@ -42,12 +40,9 @@ function canonicalPath() {
 /**
  * Return the canonical URL for the page concat the given `search`
  * and strip the hash.
- *
- * @param {string} search
- * @return {string}
  */
 
-function canonicalUrl(search) {
+function canonicalUrl(search: string): string {
   var canon = canonical();
   if (canon) return includes('?', canon) ? canon : canon + search;
   var url = window.location.href;

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -14,18 +14,15 @@ var store = require('@segment/store');
  * @param {Object} options
  */
 
-function Store(options) {
+function Store(options?: { enabled: boolean }) {
   this.options(options);
 }
 
 /**
  * Set the `options` for the store.
- *
- * @param {Object} options
- *   @field {Boolean} enabled (true)
  */
 
-Store.prototype.options = function(options) {
+Store.prototype.options = function(options: { enabled?: boolean }) {
   if (arguments.length === 0) return this._options;
 
   options = options || {};
@@ -37,35 +34,27 @@ Store.prototype.options = function(options) {
 
 /**
  * Set a `key` and `value` in local storage.
- *
- * @param {string} key
- * @param {Object} value
  */
 
-Store.prototype.set = function(key, value) {
+Store.prototype.set = function(key: string, value: object) {
   if (!this.enabled) return false;
   return store.set(key, value);
 };
 
 /**
  * Get a value from local storage by `key`.
- *
- * @param {string} key
- * @return {Object}
  */
 
-Store.prototype.get = function(key) {
+Store.prototype.get = function(key: string): object {
   if (!this.enabled) return null;
   return store.get(key);
 };
 
 /**
  * Remove a value from local storage by `key`.
- *
- * @param {string} key
  */
 
-Store.prototype.remove = function(key) {
+Store.prototype.remove = function(key: string) {
   if (!this.enabled) return false;
   return store.remove(key);
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -81,3 +81,11 @@ export interface Message {
   context?: unknown;
   messageId?: string;
 }
+
+export interface PageDefaults {
+  path: string;
+  referrer: string;
+  search: string;
+  title: string;
+  url: string;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -73,3 +73,11 @@ export interface SegmentOpts {
   anonymousId?: string;
   context?: object;
 }
+
+export interface Message {
+  options?: unknown;
+  integrations?: { [key: string]: string };
+  providers?: { [key: string]: string };
+  context?: unknown;
+  messageId?: string;
+}


### PR DESCRIPTION
## Description
This PR converts `group`, `memory`, `metrics`, `normalize`, `pageDefaults` and `store` to `.ts`.

## Test plan
Testing completed successfully using `make test-e2e` and `make watch` from ajs private:
![image](https://user-images.githubusercontent.com/484013/88320857-132b6c00-ccd3-11ea-8b3b-e7f8ec5c36d8.png)
![ajscore](https://user-images.githubusercontent.com/484013/88322586-c5fcc980-ccd5-11ea-9a5d-8dd5336bc4cb.gif)


## Release plan

New version is not required because this is a dev only change