### PR TITLE
Document how to use types with the AJS snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,25 +3,24 @@
 [![CircleCI](https://circleci.com/gh/segmentio/analytics.js-core.svg?style=shield)](https://circleci.com/gh/segmentio/analytics.js-core)
 [![Codecov](https://img.shields.io/codecov/c/github/segmentio/analytics.js-core/master.svg)](https://codecov.io/gh/segmentio/analytics.js-core)
 
-This is the core of [Analytics.js][], the open-source library that powers data collection at [Segment](https://segment.com).
+This is the core of [Analytics.js](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/), the open-source library that powers data collection at [Segment](https://segment.com).
 
 To build this into a full, usable library, see the [Analytics.js](https://github.com/segmentio/analytics.js) repository.
 
-## Using Types (on versions > 4.0.0-beta.0)
+## Using Types (v.4.0.0-beta.0 and later)
 
-We've recently introduced Typescript support and types to Analytics.js Core. While the exposed types still need some work
-(pull requests are welcome!), they're ready to be used.
+We recently introduced Typescript support and types to Analytics.js Core. While the exposed types still need some work (pull requests are welcome!), they're ready to be used.
 
 ### Importing as an npm module
 
-If you use analytics.js-core as an npm module, you can leverage its types out of the box:
+If you use analytics.js-core as an npm module, you can use its types out of the box:
 <img src="https://user-images.githubusercontent.com/484013/89060070-2e235f00-d317-11ea-9fd9-e1c77aaca9f9.gif" alt="Example of Types usage in Analytics JS" width="500px">
 
 ### Using types with the AJS Snippet
 
-If you create a source at https://app.segment.com, we'll automatically generate a JS snippet that can be added to your website (for more information visit our [documentation](https://segment.com/docs/getting-started/02-simple-install/#installing-segment)).
+If you create a source at https://app.segment.com, Segement automatically generates a JS snippet that you can add to your website. (for more information visit our [documentation](https://segment.com/docs/getting-started/02-simple-install/#installing-segment)).
 
-To use types with the snippet, all you need to do is add `analytics` as part of the global module.
+To use types with the snippet, add `analytics` as part of the global module.
 Something like this:
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ We've recently introduced Typescript support and types to Analytics.js Core. Whi
 ### Importing as an npm module
 
 If you use analytics.js-core as an npm module, you can leverage its types out of the box:
-<img src="![types](https://user-images.githubusercontent.com/484013/88733944-bbcf3680-d0ec-11ea-904c-a63b68f4975e.gif)" alt="Example of using analytics js types" width="500px">
+<img src="https://user-images.githubusercontent.com/484013/89060070-2e235f00-d317-11ea-9fd9-e1c77aaca9f9.gif" alt="Example of Types usage in Analytics JS" width="500px">
 
 ### Using types with the AJS Snippet
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you use analytics.js-core as an npm module, you can use its types out of the 
 
 ### Using types with the AJS Snippet
 
-If you create a source at https://app.segment.com, Segement automatically generates a JS snippet that you can add to your website. (for more information visit our [documentation](https://segment.com/docs/getting-started/02-simple-install/#installing-segment)).
+If you create a source at https://app.segment.com, Segement automatically generates a JS snippet that you can add to your website. (for more information visit our [documentation](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/quickstart/)).
 
 To use types with the snippet, add `analytics` as part of the global module.
 Something like this:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the core of [Analytics.js][], the open-source library that powers data c
 
 To build this into a full, usable library, see the [Analytics.js](https://github.com/segmentio/analytics.js) repository.
 
-## Using Types
+## Using Types (on versions > 4.0.0-beta.0)
 
 We've recently introduced Typescript support and types to Analytics.js Core. While the exposed types still need some work
 (pull requests are welcome!), they're ready to be used.
@@ -16,6 +16,23 @@ We've recently introduced Typescript support and types to Analytics.js Core. Whi
 
 If you use analytics.js-core as an npm module, you can leverage its types out of the box:
 <img src="![types](https://user-images.githubusercontent.com/484013/88733944-bbcf3680-d0ec-11ea-904c-a63b68f4975e.gif)" alt="Example of using analytics js types" width="500px">
+
+### Using types with the AJS Snippet
+
+If you create a source at https://app.segment.com, we'll automatically generate a JS snippet that can be added to your website (for more information visit our [documentation](https://segment.com/docs/getting-started/02-simple-install/#installing-segment)).
+
+To use types with the snippet, all you need to do is add `analytics` as part of the global module.
+Something like this:
+
+```typescript
+import { SegmentAnalytics } from '@segment/analytics.js-core';
+
+declare global {
+  interface Window {
+    analytics: SegmentAnalytics.AnalyticsJS;
+  }
+}
+```
 
 ## License
 


### PR DESCRIPTION
## Description
This PR updates AJS Core README to include documentation on how to use types when using the AJS Snippet

## Test plan
Testing not required because this is only a documentation change.


## Release plan
New version is not required because this is only a documentation change.
