### PR TITLE
[TypeScript] explicitly defines call patterns for page method

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -64,6 +64,10 @@ export declare namespace SegmentAnalytics {
     integrations?: SegmentIntegration;
   }
 
+  type PageProperties = Object;
+  type PageOptions = Object;
+  type PageCallback = () => void;
+
   interface AnalyticsJS {
     Integrations: { [name: string]: unknown };
     require: any;
@@ -215,16 +219,79 @@ export declare namespace SegmentAnalytics {
       properties?: any
     ): AnalyticsJS;
 
+
     /**
-     * Trigger a pageview, labeling the current page with an optional `category`,
-     * `name` and `properties`.
+     * Trigger a pageview.
      */
     page(
       category: string,
       name: string,
-      properties: any,
-      options: any,
-      fn: unknown
+      properties: PageProperties,
+      options: PageOptions,
+      callback: PageCallback,
+    ): AnalyticsJS;
+
+    /**
+     * Trigger a pageview.
+     */
+    page(
+      category: string,
+      name: string,
+      properties: PageProperties,
+      callback: PageCallback,
+    ): AnalyticsJS;
+
+    /**
+     * Trigger a pageview.
+     */
+    page(
+      category: string,
+      name: string,
+      callback: PageCallback,
+    ): AnalyticsJS;
+
+    /**
+     * Trigger a pageview.
+     */
+    page(
+      name: string,
+      properties: PageProperties,
+      options: PageOptions,
+      callback: PageCallback,
+    ): AnalyticsJS;
+
+    /**
+     * Trigger a pageview.
+     */
+    page(
+      name: string,
+      properties: PageProperties,
+      callback: PageCallback,
+    ): AnalyticsJS;
+
+    /**
+     * Trigger a pageview.
+     */
+    page(
+      name: string,
+      callback: PageCallback,
+    ): AnalyticsJS;
+
+    /**
+     * Trigger a pageview.
+     */
+    page(
+      properties: PageProperties,
+      options: PageOptions,
+      callback: PageCallback,
+    ): AnalyticsJS;
+
+    /**
+     * Trigger a pageview.
+     */
+    page(
+      properties: PageProperties,
+      callback: PageCallback,
     ): AnalyticsJS;
 
     /**


### PR DESCRIPTION
I noticed that the type for `page` previously required all arguments, but this doesn't match the behavior described in the [tests](https://github.com/segmentio/analytics.js-core/blob/master/test/analytics.test.js#L667-L752) or the [library](https://github.com/dimitropoulos/analytics.js-core/blob/master/lib/analytics.ts#L575-L583) itself.

I made what is here by looking at the tests (and not the library source code) because I had quite a hard time thinking through all the combinations the library source code allows (and, after all, the tests already seem to have done that).

