### PR TITLE
Replace @ndhoule/defaults with ES6 spread syntax merging

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # 4.1.5 / 2020-09-17
 
-- Replace @ndhoule/defaults with lodash.assign and ES6 spread syntax
+- Replace @ndhoule/defaults with merging via ES6 spread syntax
 
 # 4.1.4 / 2020-09-16
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 4.1.5 / 2020-09-17
+
+- Replace @ndhoule/defaults with lodash.assign and ES6 spread syntax
+
 # 4.1.4 / 2020-09-16
 
 - Replace `@ndhoule/includes` with `lodash.includes`

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -6,7 +6,7 @@ import {
   SegmentAnalytics,
   SegmentOpts,
   SegmentIntegration,
-  PageDefaults
+  PageDefaults, Message
 } from './types';
 
 import cloneDeep from 'lodash.clonedeep'
@@ -613,6 +613,10 @@ Analytics.prototype.page = function(
 
   // Ensure properties has baseline spec properties.
   // TODO: Eventually move these entirely to `options.context.page`
+  // FIXME: This is purposely not overriding `defs`. There was a bug in the logic implemented by `@ndhoule/defaults`.
+  //        This bug made it so we only would overwrite values in `defs` that were set to `undefined`.
+  //        In some cases, though, pageDefaults  will return defaults with values set to "" (such as `window.location.search` defaulting to "").
+  //        The decision to not fix this bus was made to preserve backwards compatibility.
   const defs = pageDefaults()
   properties = {
     ...properties,
@@ -993,6 +997,7 @@ Analytics.prototype._parseQuery = function(query: string): SegmentAnalytics {
  */
 
 Analytics.prototype.normalize = function(msg: {
+  options: { [key: string]: unknown }
   context: { page: Partial<PageDefaults> };
   anonymousId: string;
 }): object {

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -49,7 +49,6 @@ var querystring = require('component-querystring');
 var store = require('./store');
 var user = require('./user');
 var type = require('component-type');
-var assign = require('lodash.assign')
 
 /**
  * Initialize a new `Analytics` instance.
@@ -614,13 +613,11 @@ Analytics.prototype.page = function(
 
   // Ensure properties has baseline spec properties.
   // TODO: Eventually move these entirely to `options.context.page`
-<<<<<<< HEAD
-  const defs = pageDefaults();
-  defaults(properties, defs);
-=======
-  var defs = pageDefaults();
-  assign(properties, defs)
->>>>>>> f1bfcd9... Replace @ndhoulse/defaults with lodash.assign and ES6 spread syntax merging
+  const defs = pageDefaults()
+  properties = {
+    ...properties,
+    ...defs
+  }
 
   // Mirror user overrides to `options.context.page` (but exclude custom properties)
   // (Any page defaults get applied in `this.normalize` for consistency.)

--- a/lib/cookie.ts
+++ b/lib/cookie.ts
@@ -10,8 +10,10 @@ import cloneDeep from 'lodash.clonedeep'
 var bindAll = require('bind-all');
 var cookie = require('@segment/cookie');
 var debug = require('debug')('analytics.js:cookie');
-var defaults = require('@ndhoule/defaults');
 var topDomain = require('@segment/top-domain');
+var assign = require('lodash.assign')
+
+const MAX_AGE_ONE_YEAR = 31536000000
 
 /**
  * Initialize a new `Cookie` with `options`.
@@ -32,16 +34,17 @@ Cookie.prototype.options = function(options?: CookieOptions) {
 
   options = options || {};
 
-  var domain = '.' + topDomain(window.location.href);
+  let domain = '.' + topDomain(window.location.href);
   if (domain === '.') domain = null;
 
-  this._options = defaults(options, {
-    // default to a year
-    maxage: 31536000000,
-    path: '/',
+  const defaults: CookieOptions  = {
+    maxage: MAX_AGE_ONE_YEAR,
     domain: domain,
+    path: '/',
     sameSite: 'Lax'
-  });
+  }
+
+  this._options = assign(defaults, options);
 
   // http://curl.haxx.se/rfc/cookie_spec.html
   // https://publicsuffix.org/list/effective_tld_names.dat

--- a/lib/cookie.ts
+++ b/lib/cookie.ts
@@ -11,7 +11,6 @@ var bindAll = require('bind-all');
 var cookie = require('@segment/cookie');
 var debug = require('debug')('analytics.js:cookie');
 var topDomain = require('@segment/top-domain');
-var assign = require('lodash.assign')
 
 const MAX_AGE_ONE_YEAR = 31536000000
 
@@ -44,7 +43,10 @@ Cookie.prototype.options = function(options?: CookieOptions) {
     sameSite: 'Lax'
   }
 
-  this._options = assign(defaults, options);
+  this._options = {
+    ...defaults,
+    ...options
+  };
 
   // http://curl.haxx.se/rfc/cookie_spec.html
   // https://publicsuffix.org/list/effective_tld_names.dat

--- a/lib/entity.ts
+++ b/lib/entity.ts
@@ -10,7 +10,6 @@ import assignIn from 'lodash.assignin'
 
 var cookie = require('./cookie');
 var debug = require('debug')('analytics:entity');
-var defaults = require('@ndhoule/defaults');
 var memory = require('./memory');
 var store = require('./store');
 var isodateTraverse = require('@segment/isodate-traverse');
@@ -74,7 +73,10 @@ Entity.prototype.storage = function() {
 
 Entity.prototype.options = function(options?: InitOptions) {
   if (arguments.length === 0) return this._options;
-  this._options = defaults(options || {}, this.defaults || {});
+  this._options = {
+    ...this.defaults,
+    ...options
+  }
 };
 
 /**

--- a/lib/normalize.ts
+++ b/lib/normalize.ts
@@ -6,10 +6,11 @@ import includes from 'lodash.includes'
  */
 
 var debug = require('debug')('analytics.js:normalize');
-var defaults = require('@ndhoule/defaults');
 var type = require('component-type');
 var uuid = require('uuid/v4');
 var md5 = require('spark-md5').hash;
+var assign = require('lodash.assign')
+
 
 /**
  * HOP.
@@ -88,7 +89,7 @@ function normalize(msg: Message, list: Array<any>): NormalizedMessage {
   delete msg.options;
   ret.integrations = integrations;
   ret.context = context;
-  ret = defaults(ret, msg);
+  ret = assign(msg, ret);
   debug('->', ret);
   return ret;
 

--- a/lib/normalize.ts
+++ b/lib/normalize.ts
@@ -9,7 +9,6 @@ var debug = require('debug')('analytics.js:normalize');
 var type = require('component-type');
 var uuid = require('uuid/v4');
 var md5 = require('spark-md5').hash;
-var assign = require('lodash.assign')
 
 
 /**
@@ -89,7 +88,11 @@ function normalize(msg: Message, list: Array<any>): NormalizedMessage {
   delete msg.options;
   ret.integrations = integrations;
   ret.context = context;
-  ret = assign(msg, ret);
+  ret = {
+    ...msg,
+    ...ret
+  }
+
   debug('->', ret);
   return ret;
 

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,12 +1,14 @@
 'use strict';
 
+import { StoreOptions } from './types';
+
 /*
  * Module dependencies.
  */
 
 var bindAll = require('bind-all');
-var defaults = require('@ndhoule/defaults');
 var store = require('@segment/store');
+var assign = require('lodash.assign')
 
 /**
  * Initialize a new `Store` with `options`.
@@ -22,11 +24,11 @@ function Store(options?: { enabled: boolean }) {
  * Set the `options` for the store.
  */
 
-Store.prototype.options = function(options?: { enabled?: boolean }) {
+Store.prototype.options = function(options?: StoreOptions) {
   if (arguments.length === 0) return this._options;
 
   options = options || {};
-  defaults(options, { enabled: true });
+  options = assign({ enabled: true }, options);
 
   this.enabled = options.enabled && store.enabled;
   this._options = options;

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -8,7 +8,6 @@ import { StoreOptions } from './types';
 
 var bindAll = require('bind-all');
 var store = require('@segment/store');
-var assign = require('lodash.assign')
 
 /**
  * Initialize a new `Store` with `options`.
@@ -28,7 +27,10 @@ Store.prototype.options = function(options?: StoreOptions) {
   if (arguments.length === 0) return this._options;
 
   options = options || {};
-  options = assign({ enabled: true }, options);
+  options = {
+    enabled: true,
+    ...options
+  };
 
   this.enabled = options.enabled && store.enabled;
   this._options = options;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -37,6 +37,7 @@ export interface CookieOptions {
   domain?: string;
   path?: string;
   secure?: boolean;
+  sameSite?: string
 }
 
 export interface MetricsOptions {
@@ -46,7 +47,7 @@ export interface MetricsOptions {
   maxQueueSize?: number;
 }
 
-interface StoreOptions {
+export interface StoreOptions {
   enabled?: boolean;
 }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "homepage": "https://github.com/segmentio/analytics.js-core#readme",
   "dependencies": {
-    "@ndhoule/defaults": "^2.0.1",
     "@segment/canonical": "^1.0.0",
     "@segment/cookie": "^1.1.5",
     "@segment/is-meta": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-core",
   "author": "Segment <friends@segment.com>",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "The hassle-free way to integrate analytics into any web application.",
   "types": "lib/index.d.ts",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.includes": "^4.3.0",
     "lodash.pick": "^4.4.0",
+    "lodash.assign": "^4.2.0",
     "new-date": "^1.0.0",
     "next-tick": "^0.2.2",
     "package-json-versionify": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.includes": "^4.3.0",
     "lodash.pick": "^4.4.0",
-    "lodash.assign": "^4.2.0",
     "new-date": "^1.0.0",
     "next-tick": "^0.2.2",
     "package-json-versionify": "^1.0.4",

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -829,6 +829,22 @@ describe('Analytics', function() {
       });
     });
 
+    it('should should not overwrite context.page values due to an existing bug', function() {
+      analytics.page({ prop: true, context: { page: { search: "lol" } } }, { context: { page: { search: "" } } });
+      var page = analytics._invoke.args[0][1];
+      // FIXME: This assert should fail once the bug is fixed
+      assert.notDeepEqual(page.context(), {
+        page: {
+          ...defaults,
+          search: "lol",
+        },
+      });
+      // FIXME: This assert should fail once the bug is fixed
+      assert.deepEqual(page.context(), {
+        page: defaults,
+      });
+    });
+
     it('should emit page', function(done) {
       analytics.once('page', function(category, name, props, opts) {
         assert(category === 'category');

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -11,7 +11,6 @@ var pageDefaults = require('../build/pageDefaults');
 var sinon = require('sinon');
 var tick = require('next-tick');
 var trigger = require('compat-trigger-event');
-var assign = require('lodash.assign');
 
 var Identify = Facade.Identify;
 var cookie = Analytics.cookie;
@@ -1615,7 +1614,10 @@ describe('Analytics', function() {
       var track = analytics._invoke.args[0][1];
       assert.deepEqual(
         track.context().page,
-        assign(contextPage, { title: 'lol' })
+        {
+          ...contextPage,
+          title: 'lol'
+        }
       );
     });
 

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -772,6 +772,17 @@ describe('Analytics', function() {
       assert.deepEqual(page.options('AdRoll'), { opt: true });
     });
 
+    it('should use the initialize .integrations option', function() {
+      analytics.initialize(settings, {
+        integrations: {
+          Test: false
+        }
+      });
+      analytics.page({ prop: true });
+      var page = analytics._invoke.args[0][1];
+      assert.deepEqual(page.obj.integrations, { Test: false });
+    });
+
     it('should be able to override the initialize .integrations option', function() {
       analytics.initialize(settings, {
         integrations: {

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -11,6 +11,8 @@ var pageDefaults = require('../build/pageDefaults');
 var sinon = require('sinon');
 var tick = require('next-tick');
 var trigger = require('compat-trigger-event');
+var assign = require('lodash.assign');
+
 var Identify = Facade.Identify;
 var cookie = Analytics.cookie;
 var group = analytics.group();
@@ -769,17 +771,6 @@ describe('Analytics', function() {
       );
       var page = analytics._invoke.args[0][1];
       assert.deepEqual(page.options('AdRoll'), { opt: true });
-    });
-
-    it('should use the initialize .integrations option', function() {
-      analytics.initialize(settings, {
-        integrations: {
-          Test: false
-        }
-      });
-      analytics.page({ prop: true });
-      var page = analytics._invoke.args[0][1];
-      assert.deepEqual(page.obj.integrations, { Test: false });
     });
 
     it('should be able to override the initialize .integrations option', function() {
@@ -1606,6 +1597,26 @@ describe('Analytics', function() {
       analytics.track('event');
       var track = analytics._invoke.args[0][1];
       assert.deepEqual(track.context(), { page: contextPage });
+    });
+
+    it('should support overwriting context.page fields', function() {
+      analytics.track(
+        'event',
+        {},
+        {
+          context: {
+            page: {
+              title: 'lol'
+            }
+          }
+        }
+      );
+
+      var track = analytics._invoke.args[0][1];
+      assert.deepEqual(
+        track.context().page,
+        assign(contextPage, { title: 'lol' })
+      );
     });
 
     it('should accept context.traits', function() {

--- a/test/cookie.test.ts
+++ b/test/cookie.test.ts
@@ -63,6 +63,15 @@ describe('cookie', function() {
       assert(cookie.options().maxage === 31536000000);
     });
 
+    it('should have default options', function() {
+      cookie.options({ domain: '' });
+
+      assert(cookie.options().maxage === 31536000000);
+      assert(cookie.options().path === '/');
+      assert(cookie.options().domain === '');
+      assert(cookie.options().sameSite === 'Lax');
+    });
+
     it('should set the domain correctly', function() {
       cookie.options({ domain: '' });
       assert(cookie.options().domain === '');

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -64,6 +64,18 @@ describe('normalize', function() {
         }
       });
     });
+
+    it('should merge with defaults', function() {
+      opts.context = { foo: 5 };
+      var out = normalize(msg, list);
+      assert.deepEqual(out.integrations, {});
+      assert.deepEqual(out.context, { foo: 5 });
+
+      msg.options = { integrations: { Segment: true }, context: { foo: 6 } };
+      out = normalize(msg, list);
+      assert.deepEqual(out.integrations, { Segment: true });
+      assert.deepEqual(out.context, { foo: 6 });
+    });
   });
 
   describe('integrations', function() {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -43,5 +43,11 @@ describe('store', function() {
       assert(store.options().enabled === false);
       assert(store.enabled === false);
     });
+
+    it('should have default options', function() {
+      store.options({});
+
+      assert(store.options().enabled);
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5986,6 +5986,7 @@ lodash-es@^4.17.11:
 lodash.assign@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
+  integrity sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=
 
 lodash.assignin@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
## Description

This PR rips out the third party library `@ndhoule/defaults` and replaces it with merges via the ES6's object spread syntax.

## Test plan

Testing completed successfully using verifying existing unit tests pass and adding additional test coverage.  Also verified with e2e tests using the scenarios below:

Each scenario shows me overriding `context.page.search` with `lol`


- [x] properties merged with `pageDefaults` on a `Track` call and supports overrides
![Screen Shot 2020-09-16 at 5 52 46 PM](https://user-images.githubusercontent.com/312291/93396327-7524cf80-f845-11ea-9da2-c71aa1de22cf.png)


- [x] properties merged with `pageDefaults` on a `Page` call and supports overrides
![Screen Shot 2020-09-16 at 5 54 53 PM](https://user-images.githubusercontent.com/312291/93396486-c5039680-f845-11ea-992d-84a1792f9a91.png)

*Note*: There is an existing bug where the `properties` doesn't reflect changes to `context.page`.  This does not happen in other methods


- [x] `context.page` with defaults exists on a `Identify` call and supports overrides
![Screen Shot 2020-09-16 at 5 53 57 PM](https://user-images.githubusercontent.com/312291/93396413-9dacc980-f845-11ea-95bb-7e2d5b51a0f0.png)


- [x] `context.page` with defaults exists on an `Alias` call and supports overrides
![Screen Shot 2020-09-16 at 5 55 20 PM](https://user-images.githubusercontent.com/312291/93396508-cd5bd180-f845-11ea-93a4-af75fc066372.png)


- [x] `cookie` defaults are set
![Screen Shot 2020-09-17 at 8 33 36 AM](https://user-images.githubusercontent.com/312291/93470850-852dc500-f8c0-11ea-9f8e-251080ac10f5.png)


- [x] `store` enabled by default and values are stored (tested with `Identify`)
![Screen Shot 2020-09-17 at 8 38 55 AM](https://user-images.githubusercontent.com/312291/93471391-477d6c00-f8c1-11ea-9b5a-25800cba1930.png)


## Checklist

- [X] Thorough explanation of the issue/solution, and a link to the related issue
- [X] CI tests are passing
- [X] Unit tests were written for any new code
- [X] Code coverage is at least maintained, or increased.
