### PR TITLE
Replace @ndhoule/foldl with Array.prototype.reduce

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 4.0.2 / 2020-09-01
+
+- Replace @ndhoule/foldl with Array.prototype.reduce
+
 # 4.0.1 / 2020-08-21
 
 - Minor version bump since previous version was published incorrectly. No code change.

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -939,17 +939,13 @@ Analytics.prototype._parseQuery = function(query: string): SegmentAnalytics {
   function pickPrefix(prefix: string, object: object) {
     var length = prefix.length;
     var sub;
-    return foldl(
-      function(acc, val, key) {
-        if (key.substr(0, length) === prefix) {
-          sub = key.substr(length);
-          acc[sub] = val;
-        }
-        return acc;
-      },
-      {},
-      object
-    );
+    return Object.keys(object).reduce(function(acc, key) {
+      if (key.substr(0, length) === prefix) {
+        sub = key.substr(length);
+        acc[sub] = object[key];
+      }
+      return acc;
+    }, {});
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "@ndhoule/defaults": "^2.0.1",
     "@ndhoule/extend": "^2.0.0",
-    "@ndhoule/foldl": "^2.0.1",
     "@ndhoule/includes": "^2.0.1",
     "@ndhoule/keys": "^2.0.0",
     "@ndhoule/pick": "^2.0.0",


### PR DESCRIPTION
## Description

This PR removes the library `@ndhoule/foldr` in favor of the function `Array.prototype.reduce`
## Test plan

Testing completed successfully by verifying existing unit tests pass

## Checklist

- [x] Thorough explanation of the issue/solution, and a link to the related issue
- [x] CI tests are passing
- [x] Unit tests were written for any new code
- [x] Code coverage is at least maintained, or increased.
