### PR TITLE
Upgrade TypeScript to 4.0.2

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,15 +1,18 @@
+# 4.0.0 / 2020-08-20
 
-4.0.0-beta.1 / 2020-07-30
-=========================
+- Drop beta release
+- TypeScript 4
 
-  * export interfaces
-  * fix importing types issues
+# 4.0.0-beta.1 / 2020-07-30
 
-3.13.8 / 2020-07-29
-===================
+- export interfaces
+- fix importing types issues
 
-  * Add --declaration back to build scripts
-  * Publish v3.13.7 (#176)
+# 3.13.8 / 2020-07-29
+
+- Add --declaration back to build scripts
+- Publish v3.13.7 (#176)
+
 # 3.13.7 / 2020-07-29
 
 - Publish types to npm

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "sinon": "^1.7.3",
     "snyk": "^1.83.0",
     "ts-node": "^8.10.2",
-    "typescript": "^3.9.3",
+    "typescript": "^4.0.2",
     "wait-on": "^5.0.1",
     "watchify": "^3.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-core",
   "author": "Segment <friends@segment.com>",
-  "version": "4.0.0-beta.1",
+  "version": "4.0.0",
   "description": "The hassle-free way to integrate analytics into any web application.",
   "types": "lib/index.d.ts",
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -8048,10 +8048,10 @@ typescript@^2.5.1:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
 
-typescript@^3.9.3:
-  version "3.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.3.tgz#d3ac8883a97c26139e42df5e93eeece33d610b8a"
-  integrity sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==
+typescript@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
+  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
 uglify-js@^2.6:
   version "2.8.29"


### PR DESCRIPTION
## Description

This PR upgrades TypeScript to the latest version.  We are also dropping `beta` from the current version 🎉 

## Test plan

Testing not required because it is a dev-only change

## Release plan

New version not required because it is a dev only change

## Checklist

- [x] Thorough explanation of the issue/solution, and a link to the related issue
- [x] CI tests are passing
- [x] Unit tests were written for any new code
- [x] Code coverage is at least maintained, or increased.
