### PR TITLE
Bump version to 4.0.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 4.0.1 / 2020-08-21
+
+- Minor version bump since previous version was published incorrectly. No code change.
+
 # 4.0.0 / 2020-08-20
 
 - Drop beta release

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-core",
   "author": "Segment <friends@segment.com>",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "The hassle-free way to integrate analytics into any web application.",
   "types": "lib/index.d.ts",
   "keywords": [


### PR DESCRIPTION
## Description

This PR bumps the version of AJS.  Version 4.0.0 was published incorrectly.  It is a no-op change

## Test plan

Testing not required because this is a no-op change

## Checklist

- [x] Thorough explanation of the issue/solution, and a link to the related issue
- [x] CI tests are passing
- [x] Unit tests were written for any new code
- [x] Code coverage is at least maintained, or increased.
