### PR TITLE
Bump deps with low vulns

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 4.0.3 / 2020-09-11
+
+- Bump `debug` to a version that fixed security vulnerabilities.
+
 # 4.0.2 / 2020-09-01
 
 - Replace @ndhoule/foldl with Array.prototype.reduce

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-core",
   "author": "Segment <friends@segment.com>",
-  "version": "4.0.1",
+  "version": "4.0.3",
   "description": "The hassle-free way to integrate analytics into any web application.",
   "types": "lib/index.d.ts",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "component-querystring": "^2.0.0",
     "component-type": "^1.2.1",
     "component-url": "^0.2.1",
-    "debug": "^0.7.4",
+    "debug": "^2.6.9",
     "extend": "3.0.2",
     "inherits": "^2.0.1",
     "install": "^0.7.3",
@@ -87,7 +87,7 @@
     "eslint-plugin-require-path-exists": "^1.1.8",
     "express": "^4.17.1",
     "husky": "^0.14.3",
-    "jquery": "^3.2.1",
+    "jquery": "^3.5.0",
     "karma": "5.1.1",
     "karma-browserify": "^7.0.0",
     "karma-chrome-launcher": "^3.1.0",
@@ -101,7 +101,6 @@
     "lint-staged": "^10.2.13",
     "lodash": "^4.17.20",
     "mocha": "^4.1.0",
-    "node-fetch": "2.6.1",
     "np": "^6.5.0",
     "prettier-eslint-cli": "5.0.0",
     "proclaim": "^3.5.1",
@@ -131,6 +130,8 @@
     "buffer": "^4.9.2",
     "assert": "1.5.0",
     "browserify": "16.5.2",
-    "lodash": "4.17.20"
+    "lodash": "4.17.20",
+    "node-fetch": "2.6.1",
+    "elliptic": "^6.5.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2845,10 +2845,6 @@ debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@~4.1.0:
   dependencies:
     ms "^2.1.1"
 
-debug@^0.7.4:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-0.7.4.tgz#06e1ea8082c2cb14e39806e22e2f6f757f92af39"
-
 decamelize-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
@@ -3184,9 +3180,10 @@ elegant-spinner@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
 
-elliptic@^6.0.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.0.tgz#cac9af8762c85836187003c8dfe193e5e2eae5df"
+elliptic@^6.0.0, elliptic@^6.5.3:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
+  integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"
@@ -5284,9 +5281,10 @@ istanbul-reports@^3.0.0:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-jquery@^3.2.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
+jquery@^3.5.0:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
 js-beautify@^1.11.0:
   version "1.13.0"
@@ -6653,15 +6651,10 @@ node-environment-flags@1.0.5:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
 
-node-fetch@2.6.1:
+node-fetch@2.6.1, node-fetch@^2.2.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
-
-node-fetch@^2.2.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 nopt@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Description

This PR addresses some dependencies with low vulnerabilities.  The packages in question are:

- `jquery`
- `node-fetch`
- `debug`

These deps were either manually updated or enforced to a safe version via the `resolutions` config


## Test plan

Testing completed successfully using unit tests.


## Checklist

- [x] Thorough explanation of the issue/solution, and a link to the related issue
- [x] CI tests are passing
- [x] Unit tests were written for any new code
- [x] Code coverage is at least maintained, or increased.
