### PR TITLE
Change the args of the main methods to be optional

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # 4.0.4 / 2020-09-11
 
-- Change the arguments of the main methods to be optional in the typedef to match the documentation. (#202)
+- Change the arguments of the main methods to be optional in the typedef to match the documentation. (#203)
 
 # 4.0.3 / 2020-09-11
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 4.0.4 / 2020-09-11
+
+- Change the arguments of the main methods to be optional in the typedef to match the documentation. (#202)
+
 # 4.0.3 / 2020-09-11
 
 - Bump `debug` to a version that fixed security vulnerabilities.

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -297,10 +297,10 @@ Analytics.prototype.add = function(integration: {
  */
 
 Analytics.prototype.identify = function(
-  id: string,
-  traits: unknown,
-  options: SegmentOpts,
-  fn: Function | SegmentOpts
+  id?: string,
+  traits?: unknown,
+  options?: SegmentOpts,
+  fn?: Function | SegmentOpts
 ): SegmentAnalytics {
   // Argument reshuffling.
   /* eslint-disable no-unused-expressions, no-sequences */
@@ -355,9 +355,9 @@ Analytics.prototype.user = function(): object {
 
 Analytics.prototype.group = function(
   id: string,
-  traits: unknown,
-  options: unknown,
-  fn: unknown
+  traits?: unknown,
+  options?: unknown,
+  fn?: unknown
 ): SegmentAnalytics {
   /* eslint-disable no-unused-expressions, no-sequences */
   if (!arguments.length) return group;
@@ -399,9 +399,9 @@ Analytics.prototype.group = function(
 
 Analytics.prototype.track = function(
   event: string,
-  properties: unknown,
-  options: unknown,
-  fn: unknown
+  properties?: unknown,
+  options?: unknown,
+  fn?: unknown
 ): SegmentAnalytics {
   // Argument reshuffling.
   /* eslint-disable no-unused-expressions, no-sequences */
@@ -564,11 +564,11 @@ Analytics.prototype.trackSubmit = Analytics.prototype.trackForm = function(
  */
 
 Analytics.prototype.page = function(
-  category: string,
-  name: string,
-  properties: any,
-  options: any,
-  fn: unknown
+  category?: string,
+  name?: string,
+  properties?: any,
+  options?: any,
+  fn?: unknown
 ): SegmentAnalytics {
   // Argument reshuffling.
   /* eslint-disable no-unused-expressions, no-sequences */

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -130,10 +130,10 @@ export declare namespace SegmentAnalytics {
      * Identify a user by optional `id` and `traits`.
      */
     identify(
-      id: string,
-      traits: unknown,
-      options: SegmentOpts,
-      fn: Function | SegmentOpts
+      id?: string,
+      traits?: unknown,
+      options?: SegmentOpts,
+      fn?: Function | SegmentOpts
     ): AnalyticsJS;
 
     /**
@@ -147,9 +147,9 @@ export declare namespace SegmentAnalytics {
      */
     group(
       id: string,
-      traits: unknown,
-      options: unknown,
-      fn: unknown
+      traits?: unknown,
+      options?: unknown,
+      fn?: unknown
     ): AnalyticsJS;
 
     /**
@@ -157,9 +157,9 @@ export declare namespace SegmentAnalytics {
      */
     track(
       event: string,
-      properties: unknown,
-      options: unknown,
-      fn: unknown
+      properties?: unknown,
+      options?: unknown,
+      fn?: unknown
     ): AnalyticsJS;
 
     /**
@@ -220,11 +220,11 @@ export declare namespace SegmentAnalytics {
      * `name` and `properties`.
      */
     page(
-      category: string,
-      name: string,
-      properties: any,
-      options: any,
-      fn: unknown
+      category?: string,
+      name?: string,
+      properties?: any,
+      options?: any,
+      fn?: unknown
     ): AnalyticsJS;
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-core",
   "author": "Segment <friends@segment.com>",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "The hassle-free way to integrate analytics into any web application.",
   "types": "lib/index.d.ts",
   "keywords": [


### PR DESCRIPTION
## Description

This changes the args of the main methods to be optional to match the documentation:
https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/#basic-tracking-methods

## Test plan

Testing completed successfully by checking that the generated typedef has correct types for the method args.