### PR TITLE
Replace @ndhoule/extend with lodash.assignin

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 4.1.2 / 2020-09-16
+
+- Replaces `@ndhoule/extend` with `lodash.assignin`
+
 # 4.1.1 / 2020-09-15
 
 - Enable `esModuleInterop` in `tsconfig.json`

--- a/lib/entity.ts
+++ b/lib/entity.ts
@@ -2,6 +2,7 @@
 
 import { InitOptions } from './types';
 import cloneDeep from 'lodash.clonedeep'
+import assignIn from 'lodash.assignin'
 
 /*
  * Module dependencies.
@@ -10,7 +11,6 @@ import cloneDeep from 'lodash.clonedeep'
 var cookie = require('./cookie');
 var debug = require('debug')('analytics:entity');
 var defaults = require('@ndhoule/defaults');
-var extend = require('@ndhoule/extend');
 var memory = require('./memory');
 var store = require('./store');
 var isodateTraverse = require('@segment/isodate-traverse');
@@ -221,10 +221,16 @@ Entity.prototype._setTraits = function(traits: object) {
 
 Entity.prototype.identify = function(id?: string, traits?: object) {
   traits = traits || {};
-  var current = this.id();
-  if (current === null || current === id)
-    traits = extend(this.traits(), traits);
-  if (id) this.id(id);
+  const current = this.id();
+
+  if (current === null || current === id) {
+    traits = assignIn(this.traits(), traits);
+  }
+
+  if (id) {
+    this.id(id);
+  }
+
   this.debug('identify %o, %o', id, traits);
   this.traits(traits);
   this.save();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-core",
   "author": "Segment <friends@segment.com>",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "The hassle-free way to integrate analytics into any web application.",
   "types": "lib/index.d.ts",
   "keywords": [
@@ -31,7 +31,6 @@
   "homepage": "https://github.com/segmentio/analytics.js-core#readme",
   "dependencies": {
     "@ndhoule/defaults": "^2.0.1",
-    "@ndhoule/extend": "^2.0.0",
     "@ndhoule/includes": "^2.0.1",
     "@ndhoule/pick": "^2.0.0",
     "@segment/canonical": "^1.0.0",
@@ -54,6 +53,7 @@
     "inherits": "^2.0.1",
     "install": "^0.7.3",
     "is": "^3.1.0",
+    "lodash.assignin": "^4.2.0",
     "lodash.clonedeep": "^4.5.0",
     "new-date": "^1.0.0",
     "next-tick": "^0.2.2",

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -1,4 +1,4 @@
-'use strict';
+import assignIn from 'lodash.assignin'
 
 var Analytics = require('../build').constructor;
 var Facade = require('segmentio-facade');
@@ -6,7 +6,6 @@ var analytics = require('../build');
 var assert = require('proclaim');
 var bind = require('component-event').bind;
 var createIntegration = require('@segment/analytics.js-integration');
-var extend = require('@ndhoule/extend');
 var type = require('component-type');
 var pageDefaults = require('../build/pageDefaults');
 var sinon = require('sinon');
@@ -836,7 +835,7 @@ describe('Analytics', function() {
         assert.deepEqual(opts, { context: { page: defaults } });
         assert.deepEqual(
           props,
-          extend(defaults, { category: 'category', name: 'name' })
+          assignIn({ category: 'category', name: 'name' }, defaults)
         );
         done();
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5994,6 +5994,7 @@ lodash.assign@^4.2.0:
 lodash.assignin@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
+  integrity sha1-uo31+4QesKPoBEIysOJjqNxqKKI=
 
 lodash.clone@^4.5.0:
   version "4.5.0"


### PR DESCRIPTION
## Description

This PR replaces `@ndhoule/extend` with `lodash.assignin`. 

## Test plan


- Testing completed successfully using e2e tests and unit tests

![Screen Shot 2020-09-15 at 3 15 48 PM](https://user-images.githubusercontent.com/312291/93254442-5b608b00-f766-11ea-99e2-bf68fb053804.png)


![Screen Shot 2020-09-15 at 3 15 30 PM](https://user-images.githubusercontent.com/312291/93254421-500d5f80-f766-11ea-8a17-7409b6444d37.png)


## Checklist

- [x] Thorough explanation of the issue/solution, and a link to the related issue
- [x] CI tests are passing
- [x] Unit tests were written for any new code
- [x] Code coverage is at least maintained, or increased.