### PR TITLE
Turn on esModuleInterop

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 4.1.1 / 2020-09-15
+
+- Enable `esModuleInterop` in `tsconfig.json`
+
 # 4.1.0 / 2020-09-14
 
 - Replaces `utils/clone` with `lodash.deepclone`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-core",
   "author": "Segment <friends@segment.com>",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "The hassle-free way to integrate analytics into any web application.",
   "types": "lib/index.d.ts",
   "keywords": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "esModuleInterop": true,
     "module": "commonjs",
     "target": "ES5",
     "allowJs": true,


### PR DESCRIPTION
## Description


This PR turns on the `esModuleInterop` tsconfig setting.  This setting currently defaults to `false` and is causing issues in versions newer than 4.0.4.

Fixes #205 

See more details https://github.com/lodash/lodash/issues/3192#issuecomment-411963038


## Test plan

Testing completed successfully using e2e tests and sandbox with 4.1.1-beta1 version

## Checklist


- [x] Thorough explanation of the issue/solution, and a link to the related issue
- [x] CI tests are passing
- [x] Unit tests were written for any new code
- [x] Code coverage is at least maintained, or increased.

