### PR TITLE
Replace @ndhoule/pick with lodash.pick

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 4.1.3 / 2020-09-16
+
+- Replace `@ndhoule/pick` with `lodash.pick`
+
 # 4.1.2 / 2020-09-16
 
 - Replaces `@ndhoule/extend` with `lodash.assignin`

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -9,6 +9,7 @@ import {
 } from './types';
 
 import cloneDeep from 'lodash.clonedeep'
+import pick from 'lodash.pick'
 
 var _analytics = global.analytics;
 
@@ -42,7 +43,6 @@ var nextTick = require('next-tick');
 var normalize = require('./normalize');
 var on = require('component-event').bind;
 var pageDefaults = require('./pageDefaults');
-var pick = require('@ndhoule/pick');
 var prevent = require('@segment/prevent-default');
 var querystring = require('component-querystring');
 var store = require('./store');
@@ -600,20 +600,20 @@ Analytics.prototype.page = function(
 
   // Ensure properties has baseline spec properties.
   // TODO: Eventually move these entirely to `options.context.page`
-  var defs = pageDefaults();
+  const defs = pageDefaults();
   defaults(properties, defs);
 
   // Mirror user overrides to `options.context.page` (but exclude custom properties)
   // (Any page defaults get applied in `this.normalize` for consistency.)
   // Weird, yeah--moving special props to `context.page` will fix this in the long term.
-  var overrides = pick(Object.keys(defs), properties);
+  const overrides = pick(properties, Object.keys(defs));
   if (!is.empty(overrides)) {
     options = options || {};
     options.context = options.context || {};
     options.context.page = overrides;
   }
 
-  var msg = this.normalize({
+  const msg = this.normalize({
     properties: properties,
     category: category,
     options: options,

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "@ndhoule/defaults": "^2.0.1",
     "@ndhoule/includes": "^2.0.1",
-    "@ndhoule/pick": "^2.0.0",
     "@segment/canonical": "^1.0.0",
     "@segment/cookie": "^1.1.5",
     "@segment/is-meta": "^1.0.0",
@@ -55,6 +54,7 @@
     "is": "^3.1.0",
     "lodash.assignin": "^4.2.0",
     "lodash.clonedeep": "^4.5.0",
+    "lodash.pick": "^4.4.0",
     "new-date": "^1.0.0",
     "next-tick": "^0.2.2",
     "package-json-versionify": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-core",
   "author": "Segment <friends@segment.com>",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "The hassle-free way to integrate analytics into any web application.",
   "types": "lib/index.d.ts",
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -315,10 +315,6 @@
   dependencies:
     "@ndhoule/each" "^2.0.1"
 
-"@ndhoule/pick@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@ndhoule/pick/-/pick-2.0.0.tgz#e1eb1a6ca3243eef56daa095c3a1612c74a52156"
-
 "@ndhoule/rest@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@ndhoule/rest/-/rest-2.0.0.tgz#0346b02a964a513ed2ba24d164f01d34f2107a0f"
@@ -6118,6 +6114,11 @@ lodash.mergewith@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
   integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
+
+lodash.pick@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+  integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
 
 lodash.reduce@^4.6.0:
   version "4.6.0"


### PR DESCRIPTION
## Description

This PR replaces the function `pick`, provided by `@ndhoule/pick`, with the version provided by `lodash.pick`

## Test plan

Testing completed successfully using unit tests and e2e tests.  Note how my prop `search` overrides the `page.context` value.

<img width="557" alt="Screen Shot 2020-09-16 at 3 06 55 PM" src="https://user-images.githubusercontent.com/312291/93381244-62eb6700-f82e-11ea-8ce7-8d572c15a11d.png">


## Checklist

- [x] Thorough explanation of the issue/solution, and a link to the related issue
- [x] CI tests are passing
- [x] Unit tests were written for any new code
- [x] Code coverage is at least maintained, or increased.

