### PR TITLE
Replace @ndhoule/includes with lodash.includes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 4.1.4 / 2020-09-16
+
+- Replace `@ndhoule/includes` with `lodash.includes`
+
 # 4.1.3 / 2020-09-16
 
 - Replace `@ndhoule/pick` with `lodash.pick`

--- a/lib/normalize.ts
+++ b/lib/normalize.ts
@@ -1,6 +1,5 @@
-'use strict';
-
 import { Message } from './types';
+import includes from 'lodash.includes'
 
 /**
  * Module Dependencies.
@@ -8,7 +7,6 @@ import { Message } from './types';
 
 var debug = require('debug')('analytics.js:normalize');
 var defaults = require('@ndhoule/defaults');
-var includes = require('@ndhoule/includes');
 var type = require('component-type');
 var uuid = require('uuid/v4');
 var md5 = require('spark-md5').hash;
@@ -43,14 +41,14 @@ interface NormalizedMessage {
 }
 
 function normalize(msg: Message, list: Array<any>): NormalizedMessage {
-  var lower = list?.map(function(s) {
+  const lower = list?.map(function(s) {
     return s.toLowerCase();
   });
-  var opts: Message = msg.options || {};
-  var integrations = opts.integrations || {};
-  var providers = opts.providers || {};
-  var context = opts.context || {};
-  var ret: {
+  const opts: Message = msg.options || {};
+  const integrations = opts.integrations || {};
+  const providers = opts.providers || {};
+  const context = opts.context || {};
+  let ret: {
     integrations?: { [key: string]: string };
     context?: unknown;
   } = {};
@@ -76,7 +74,7 @@ function normalize(msg: Message, list: Array<any>): NormalizedMessage {
   // move all toplevel options to msg
   // and the rest to context.
   Object.keys(opts).forEach(key => {
-    if (includes(key, toplevel)) {
+    if (includes(toplevel, key)) {
       ret[key] = opts[key];
     } else {
       context[key] = opts[key];
@@ -96,9 +94,9 @@ function normalize(msg: Message, list: Array<any>): NormalizedMessage {
 
   function integration(name: string) {
     return !!(
-      includes(name, list) ||
+      includes(list, name) ||
       name.toLowerCase() === 'all' ||
-      includes(name.toLowerCase(), lower)
+      includes(lower, name.toLowerCase())
     );
   }
 }

--- a/lib/pageDefaults.ts
+++ b/lib/pageDefaults.ts
@@ -1,14 +1,7 @@
-'use strict';
-
 import { PageDefaults } from './types';
-
-/*
- * Module dependencies.
- */
-
-var canonical = require('@segment/canonical');
-var includes = require('@ndhoule/includes');
-var url = require('component-url');
+import includes from 'lodash.includes'
+import canonical from '@segment/canonical'
+import url from 'component-url'
 
 /**
  * Return a default `options.context.page` object.
@@ -31,9 +24,9 @@ function pageDefaults(): PageDefaults {
  */
 
 function canonicalPath(): string {
-  var canon = canonical();
+  const canon = canonical();
   if (!canon) return window.location.pathname;
-  var parsed = url.parse(canon);
+  const parsed = url.parse(canon);
   return parsed.pathname;
 }
 
@@ -43,10 +36,10 @@ function canonicalPath(): string {
  */
 
 function canonicalUrl(search: string): string {
-  var canon = canonical();
-  if (canon) return includes('?', canon) ? canon : canon + search;
-  var url = window.location.href;
-  var i = url.indexOf('#');
+  const canon = canonical();
+  if (canon) return includes(canon, '?') ? canon : canon + search;
+  const url = window.location.href;
+  const i = url.indexOf('#');
   return i === -1 ? url : url.slice(0, i);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-core",
   "author": "Segment <friends@segment.com>",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "The hassle-free way to integrate analytics into any web application.",
   "types": "lib/index.d.ts",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "homepage": "https://github.com/segmentio/analytics.js-core#readme",
   "dependencies": {
     "@ndhoule/defaults": "^2.0.1",
-    "@ndhoule/includes": "^2.0.1",
     "@segment/canonical": "^1.0.0",
     "@segment/cookie": "^1.1.5",
     "@segment/is-meta": "^1.0.0",
@@ -54,6 +53,7 @@
     "is": "^3.1.0",
     "lodash.assignin": "^4.2.0",
     "lodash.clonedeep": "^4.5.0",
+    "lodash.includes": "^4.3.0",
     "lodash.pick": "^4.4.0",
     "new-date": "^1.0.0",
     "next-tick": "^0.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6049,6 +6049,11 @@ lodash.has@^4.5.2:
   resolved "https://registry.yarnpkg.com/lodash.has/-/lodash.has-4.5.2.tgz#d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862"
   integrity sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
+
 lodash.isarray@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-4.0.0.tgz#2aca496b28c4ca6d726715313590c02e6ea34403"


### PR DESCRIPTION
## Description

This PR replaces `includes`, provided by `@ndhoule/includes`, with the one provided by `lodash.includes`.  Unfortunately, we cannot leverage `String.prototype.includes` because it is not available in any version of IE.

## Test plan

Testing completed successfully using e2e tests and unit tests.  See examples below:

- Triggering a `page` call on a HTML document with a  `<link rel="canonical" href="http://taco:3000" />`

![Screen Shot 2020-09-16 at 4 05 44 PM](https://user-images.githubusercontent.com/312291/93386974-7f8b9d00-f836-11ea-8628-fa1e62ab18eb.png)


![Screen Shot 2020-09-16 at 4 03 31 PM](https://user-images.githubusercontent.com/312291/93386805-418e7900-f836-11ea-955f-6072dc6349a8.png)


- Triggering a `page` call on a HTML document with a  `<link rel="canonical" href="http://taco:3000?cheese=false" />`


![Screen Shot 2020-09-16 at 4 07 47 PM](https://user-images.githubusercontent.com/312291/93387156-c7aabf80-f836-11ea-9f51-3f4e5f5c02bf.png)

![Screen Shot 2020-09-16 at 4 07 18 PM](https://user-images.githubusercontent.com/312291/93387119-b9f53a00-f836-11ea-8aad-c75478b2207a.png)


- Triggering `page` with no `canonical` url
![Screen Shot 2020-09-16 at 4 08 28 PM](https://user-images.githubusercontent.com/312291/93387239-e4df8e00-f836-11ea-8fb2-28e2d5339c3a.png)



## Checklist

- [x] Thorough explanation of the issue/solution, and a link to the related issue
- [x] CI tests are passing
- [x] Unit tests were written for any new code
- [x] Code coverage is at least maintained, or increased.
