### PR TITLE
Drop @segment/canonical.  Also uprade some libs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 4.1.5 / 2020-09-20
+
+- Remove `@segment/canonical` in favor of `document.querySelector`
+
 # 4.1.5 / 2020-09-17
 
 - Replace @ndhoule/defaults with merging via ES6 spread syntax

--- a/karma.conf.ts
+++ b/karma.conf.ts
@@ -44,6 +44,7 @@ module.exports = function(config) {
         module: "commonjs",
         target: "ES5",
         allowJs: false,
+        esModuleInterop: true
       },
       include: ['test'],
       exclude: ['node_modules', 'lib', 'test-e2e/*.ts']

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -9,6 +9,8 @@ import {
   PageDefaults, Message
 } from './types';
 
+import { pageDefaults } from './pageDefaults';
+
 import cloneDeep from 'lodash.clonedeep'
 import pick from 'lodash.pick'
 
@@ -43,7 +45,6 @@ var memory = require('./memory');
 var nextTick = require('next-tick');
 var normalize = require('./normalize');
 var on = require('component-event').bind;
-var pageDefaults = require('./pageDefaults');
 var prevent = require('@segment/prevent-default');
 var querystring = require('component-querystring');
 var store = require('./store');

--- a/lib/pageDefaults.ts
+++ b/lib/pageDefaults.ts
@@ -1,32 +1,17 @@
 import { PageDefaults } from './types';
 import includes from 'lodash.includes'
-import canonical from '@segment/canonical'
 import url from 'component-url'
-
-/**
- * Return a default `options.context.page` object.
- *
- * https://segment.com/docs/spec/page/#properties
- */
-
-function pageDefaults(): PageDefaults {
-  return {
-    path: canonicalPath(),
-    referrer: document.referrer,
-    search: location.search,
-    title: document.title,
-    url: canonicalUrl(location.search)
-  };
-}
 
 /**
  * Return the canonical path for the page.
  */
 
-function canonicalPath(): string {
-  const canon = canonical();
+const canonicalPath = (): string => {
+  const canon = document.querySelector("link[rel='canonical']")
   if (!canon) return window.location.pathname;
-  const parsed = url.parse(canon);
+  const href = canon.getAttribute("href")
+
+  const parsed = url.parse(href);
   return parsed.pathname;
 }
 
@@ -35,16 +20,35 @@ function canonicalPath(): string {
  * and strip the hash.
  */
 
-function canonicalUrl(search: string): string {
-  const canon = canonical();
-  if (canon) return includes(canon, '?') ? canon : canon + search;
+const canonicalUrl = (search: string): string => {
+  const canon = document.querySelector("link[rel='canonical']")
+  if (canon) {
+    const href = canon.getAttribute("href")
+    return includes(href, '?') ? href : href + search;
+  }
+
   const url = window.location.href;
   const i = url.indexOf('#');
   return i === -1 ? url : url.slice(0, i);
 }
 
-/*
- * Exports.
+/**
+ * Return a default `options.context.page` object.
+ *
+ * https://segment.com/docs/spec/page/#properties
  */
 
-module.exports = pageDefaults;
+export const pageDefaults = (): PageDefaults => {
+  const path = canonicalPath()
+  const { referrer, title } = document
+  const { search } = location
+  const url = canonicalUrl(search)
+
+  return {
+    path,
+    referrer,
+    search,
+    title,
+    url
+  };
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-core",
   "author": "Segment <friends@segment.com>",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "description": "The hassle-free way to integrate analytics into any web application.",
   "types": "lib/index.d.ts",
   "keywords": [
@@ -30,7 +30,6 @@
   },
   "homepage": "https://github.com/segmentio/analytics.js-core#readme",
   "dependencies": {
-    "@segment/canonical": "^1.0.0",
     "@segment/cookie": "^1.1.5",
     "@segment/is-meta": "^1.0.0",
     "@segment/isodate": "^1.0.2",
@@ -73,6 +72,8 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^14.0.6",
     "@types/node-fetch": "^2.5.7",
+    "@types/proclaim": "^3.6.1",
+    "@types/sinon": "^9.0.5",
     "@typescript-eslint/eslint-plugin": "^4.1.0",
     "@typescript-eslint/parser": "^4.1.0",
     "assert": "1.5.0",
@@ -109,7 +110,7 @@
     "prettier-eslint-cli": "5.0.0",
     "proclaim": "^3.5.1",
     "puppeteer": "^5.3.0",
-    "sinon": "^1.7.3",
+    "sinon": "^1.17.7",
     "snyk": "^1.393.0",
     "ts-node": "^8.10.2",
     "typescript": "^4.0.2",

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -1,13 +1,13 @@
 import assignIn from 'lodash.assignin'
+import { pageDefaults} from '../build/pageDefaults';
+import assert from 'proclaim'
 
 var Analytics = require('../build').constructor;
 var Facade = require('segmentio-facade');
 var analytics = require('../build');
-var assert = require('proclaim');
 var bind = require('component-event').bind;
 var createIntegration = require('@segment/analytics.js-integration');
 var type = require('component-type');
-var pageDefaults = require('../build/pageDefaults');
 var sinon = require('sinon');
 var tick = require('next-tick');
 var trigger = require('compat-trigger-event');

--- a/test/pageDefaults.test.ts
+++ b/test/pageDefaults.test.ts
@@ -1,0 +1,43 @@
+import { pageDefaults }  from '../build/pageDefaults'
+import * as assert from 'proclaim'
+import sinon from 'sinon'
+
+const el = document.createElement("link")
+el.setAttribute("rel", "canonical")
+
+const loc = window.location
+
+describe('pageDefaults', () => {
+  before(() => {
+    el.setAttribute("href", "")
+    sinon.stub(document, 'querySelector').returns(el)
+  })
+
+  after(() => {
+    sinon.restore()
+  })
+
+  it('handles no canonical links', () => {
+    const defs = pageDefaults()
+    assert.isNotNull(defs.url)
+  })
+
+  it('handles canonical links', () => {
+    el.setAttribute("href", "http://www.segment.local")
+    const defs = pageDefaults()
+    assert.equal(defs.url, "http://www.segment.local")
+  })
+
+  it('handles canonical links with a path', () => {
+    el.setAttribute("href", "http://www.segment.local/test")
+    const defs = pageDefaults()
+    assert.equal(defs.url, "http://www.segment.local/test")
+    assert.equal(defs.path, "/test")
+  })
+
+  it('handles canonical links with search params in the url', () => {
+    el.setAttribute("href", "http://www.segment.local?test=true")
+    const defs = pageDefaults()
+    assert.equal(defs.url, "http://www.segment.local?test=true")
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "commonjs",
     "target": "ES5",
     "allowJs": true,
-    "outDir": "build"
+    "outDir": "build",
+    "lib": ["dom"]
   },
   "include": ["lib"],
   "exclude": ["node_modules", "*.md", "Makefile", "karma.*", "test", "test-e2e"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -449,10 +449,6 @@
   dependencies:
     utf8-encode "1"
 
-"@segment/canonical@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@segment/canonical/-/canonical-1.0.0.tgz#9adb1a731d29ab975493bf17a4ce4952985c4920"
-
 "@segment/cookie@^1.1.5":
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/@segment/cookie/-/cookie-1.1.5.tgz#cbaaf26c73a8e34103312b5bd61ebbdb710611a8"
@@ -956,6 +952,11 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/proclaim@^3.6.1":
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/@types/proclaim/-/proclaim-3.6.1.tgz#edfdf8e7b47f5996faee2313473ddb1b529847e7"
+  integrity sha512-xWRRXajUTxbh1wDSK93lb1MICrbfaD2bGtT5cgBNFmY91g1GAAhQQ7pztnkx7BSbZvf8PxfGBsMOZ9311lDrVw==
+
 "@types/qs@*":
   version "6.9.3"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.3.tgz#b755a0934564a200d3efdf88546ec93c369abd03"
@@ -995,6 +996,18 @@
   dependencies:
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
+
+"@types/sinon@^9.0.5":
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-9.0.5.tgz#56b2a12662dd8c7d081cdc511af5f872cb37377f"
+  integrity sha512-4CnkGdM/5/FXDGqL32JQ1ttVrGvhOoesLLF7VnTh4KdjK5N5VQOtxaylFqqTjnHx55MnD9O02Nbk5c1ELC8wlQ==
+  dependencies:
+    "@types/sinonjs__fake-timers" "*"
+
+"@types/sinonjs__fake-timers@*":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz#681df970358c82836b42f989188d133e218c458e"
+  integrity sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==
 
 "@types/sizzle@*":
   version "2.3.2"
@@ -4140,6 +4153,7 @@ form-data@~2.3.2:
 formatio@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
+  integrity sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=
   dependencies:
     samsam "~1.1"
 
@@ -6260,6 +6274,7 @@ loglevel@^1.6.0:
 lolex@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
+  integrity sha1-fD2mL/yzDw9agKJWbKJORdigHzE=
 
 longest@^1.0.1:
   version "1.0.1"
@@ -8249,10 +8264,12 @@ safe-regex@^1.1.0:
 samsam@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
+  integrity sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=
 
 samsam@~1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.3.tgz#9f5087419b4d091f232571e7fa52e90b0f552621"
+  integrity sha1-n1CHQZtNCR8jJXHn+lLpCw9VJiE=
 
 sauce-connect-launcher@^1.2.2:
   version "1.3.2"
@@ -8463,9 +8480,10 @@ simple-concat@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.0.tgz#7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6"
 
-sinon@^1.7.3:
+sinon@^1.17.7:
   version "1.17.7"
   resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
+  integrity sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=
   dependencies:
     formatio "1.1.1"
     lolex "1.3.2"
@@ -9923,13 +9941,7 @@ util@0.10.3:
   dependencies:
     inherits "2.0.1"
 
-"util@>=0.10.3 <1":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.11.0.tgz#c5f391beb244103d799b21077a926fef8769e1fb"
-  dependencies:
-    inherits "2.0.3"
-
-util@^0.12.1:
+"util@>=0.10.3 <1", util@^0.12.1:
   version "0.12.3"
   resolved "https://registry.yarnpkg.com/util/-/util-0.12.3.tgz#971bb0292d2cc0c892dab7c6a5d37c2bec707888"
   integrity sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==


### PR DESCRIPTION
## Description

This PR removes the `@segment/canonical` library in favor of `document.querySelector`.  We also are upgrading some test libraries like `sinon`.

Note: We can't use the latest version of sinon because sinon 2+ only supports IE11+

## Test plan

Testing completed successfully using unit tests and writing new tests


## Checklist

- [x] Thorough explanation of the issue/solution, and a link to the related issue
- [x] CI tests are passing
- [x] Unit tests were written for any new code
- [x] Code coverage is at least maintained, or increased.