### PR TITLE
Merge PR #184: adds types for Segment Integration Settings

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -5,7 +5,14 @@ export declare namespace SegmentAnalytics {
     context?: object;
   }
 
-  interface IntegrationsSettings {
+  type IntegrationsSettings = IntegrationSettings | SegmentIOIntegrationSettings
+
+  interface IntegrationSettings {
+    [key: string]: unknown
+  }
+
+  // TODO: Long term, this should probably live in analytics.js-integrations
+  interface SegmentIOIntegrationSettings {
     addBundledMetadata: boolean;
     apiHost?: string;
     apiKey?: string;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -6,8 +6,14 @@ export declare namespace SegmentAnalytics {
   }
 
   interface IntegrationsSettings {
-    // TODO remove `any`
-    [key: string]: any;
+    addBundledMetadata: boolean;
+    apiHost?: string;
+    apiKey?: string;
+    crossDomainIdServers?: string[];
+    deleteCrossDomainId?: boolean;
+    retryQueue: boolean;
+    saveCrossDomainIdInLocalStorage: boolean;
+    unbundledIntegrations: any[];
   }
 
   interface CookieOptions {


### PR DESCRIPTION
## Description

This PR merges #184, which focused on adding basic types for the Segment.io Integration.  I tweaked the types, slightly, since we still don't have a great story on type definitions for _all_ integrations.

## Test plan

Testing not required because it is a dev-only change


## Release plan


New version is not required because it is a dev-only change.

## Checklist


- [x] Thorough explanation of the issue/solution, and a link to the related issue
- [x] CI tests are passing
- [x] Unit tests were written for any new code
- [x] Code coverage is at least maintained, or increased.

