### PR TITLE
pin trim version

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+# 4.1.6 / 2020-11-24
+
+- Update `trim` package to address ReDoS vulnerability
+
 # 4.1.5 / 2020-09-20
 
 - Remove `@segment/canonical` in favor of `document.querySelector`

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "browserify": "16.5.2",
     "lodash": "4.17.20",
     "node-fetch": "2.6.1",
-    "elliptic": "^6.5.3"
+    "elliptic": "^6.5.3",
+    "trim": "^1.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9475,9 +9475,10 @@ trim-newlines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.0.tgz#79726304a6a898aa8373427298d54c2ee8b1cb30"
   integrity sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==
 
-trim@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+trim@0.0.1, trim@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-1.0.0.tgz#fd1f30b878bdd2d8435fa0f2cc9cbb55f518be7d"
+  integrity sha512-UgtES1lYpE+f4WiGY5lyJlHchuGhTa/xMPH96g/B7gc+pEQPiL41s6ECm7Ky3hkhARG/u1SHGFcleJodAvQOKQ==
 
 ts-node@^8.10.2:
   version "8.10.2"


### PR DESCRIPTION
## Description
This PR patches the ReDoS vulnerability with the `trim` package. This package was used in the following dependencies: 
- `component-querystring` 
- `facade` ( the version used by AJS classic ) 
I have to go to the yarn resolution route, as the `component-querystring` hasn't published the updated package. 

<!-- # 🎉 Thanks for contributing to Analytics.js! We really appreciate your time. 🎉

To help us quickly assess your work, please document your Pull Request using this template.

Sadly, we can't merge all PRs - but you can multiply the chances of your change getting in by giving us the information we need.  If the Pull Request doesn't align well with our roadmap, we might respectfully thank you for your time, and close the issue. -->

## Test plan
Testing completed successfully using local unit tests;
Testing completed successfully using local e2e build of the final bundle;

## Release plan

<!-- Update the HISTORY.md file if we need to generate a new version of AJS for your changes.

If not, just add the following line with an explanation:
New version is not required because <verbose explantaion - for example 'it's a dev-only change'>.
-->

## Checklist

<!--
Make sure you complete the following checklist to help get your PR merged:-->

- [x] Thorough explanation of the issue/solution, and a link to the related issue
- [x] CI tests are passing
- [x] Unit tests were written for any new code
- [x] Code coverage is at least maintained, or increased.

<!--
## Respect earns Respect 👏

Please respect our Code of Conduct, in short:

- Use welcoming and inclusive language.
- Be respectful of differing viewpoints and experiences.
- Gracefully accept constructive criticism.
- Focus on what is best for the community.
- Show empathy toward other community members.

-->
