### PR TITLE
[Noop] Remove console.log from built files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-core",
   "author": "Segment <friends@segment.com>",
-  "version": "4.1.10",
+  "version": "4.1.11",
   "description": "The hassle-free way to integrate analytics into any web application.",
   "types": "lib/index.d.ts",
   "keywords": [


### PR DESCRIPTION
## Description

All this PR does is bump the version of ajs core to 4.1.11 - no changes to logic.
The actual change (removing the console.log) is on local `build/` files generated by `make build`.


## Test plan

- Testing not required because this is a no-op


## Release plan

New version is not required because this is a no-op
