### PR TITLE
Remove exposed require

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -13,10 +13,6 @@ var Analytics = require('./analytics');
 // Create a new `analytics` singleton.
 var analytics: SegmentAnalytics.AnalyticsJS = new Analytics();
 
-// Expose `require`.
-// TODO(ndhoule): Look into deprecating, we no longer need to expose it in tests
-analytics.require = require;
-
 // Expose package version.
 analytics.VERSION = require('../package.json').version;
 


### PR DESCRIPTION
## Description

Hi, we're running into the following during our webpack build 

```
⚠ ｢wdm｣: WARNING in ./node_modules/@segment/analytics.js-core/build/index.js 13:20-27
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
```
We'd like to remove the offending line to make the warning go away. From the TODO associated it looks like this isn't used anymore and was only used for tests.

## Test plan

No core changes were made here.

## Release plan

<!-- Update the HISTORY.md file if we need to generate a new version of AJS for your changes.

If not, just add the following line with an explanation:
New version is not required because <verbose explantaion - for example 'it's a dev-only change'>.
-->
A minor version bump would be awesome so we can get the new version 🙏 

## Checklist

<!--
Make sure you complete the following checklist to help get your PR merged:-->

- [x] Thorough explanation of the issue/solution, and a link to the related issue
- [x] CI tests are passing
- [x] Unit tests were written for any new code
- [x] Code coverage is at least maintained, or increased.