### PR TITLE
chore(deps): update uuid to v8 since v3.4 is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-⚠️ Be sure to check out the next generation of analytics.js! https://github.com/segmentio/analytics-next 🎉 
+⚠️ Be sure to check out the next generation of analytics.js! https://github.com/segmentio/analytics-next 🎉
 If you have an existing JavaScript source with Segment, you can enable Analytics Next in the settings of the source.
 
 # analytics.js-core
@@ -37,46 +37,49 @@ declare global {
 ```
 
 ## Using as a standalone `npm` package
-We recommend using the CDN version of `analytics.js` as it offers all the project and workspace specific settings, enabled integrations, and middleware. But if you prefer to use `analytics.js-core` as a standalone npm package using your own tooling & workflow, you can do the following: 
 
-1- Install the dependencies 
+We recommend using the CDN version of `analytics.js` as it offers all the project and workspace specific settings, enabled integrations, and middleware. But if you prefer to use `analytics.js-core` as a standalone npm package using your own tooling & workflow, you can do the following:
+
+1- Install the dependencies
+
 ```
 yarn add @segment/analytics.js-core
 yarn add @segment/analytics.js-integration-segmentio
 // you may need this depending on the bundler
-yarn add uuid@^3.4 
+yarn add uuid@^8.0.0
 ```
 
-2- Import the dependencies 
+2- Import the dependencies
+
 ```javascript
-import Analytics from "@segment/analytics.js-core/build/analytics";
-import SegmentIntegration from "@segment/analytics.js-integration-segmentio";
+import Analytics from '@segment/analytics.js-core/build/analytics';
+import SegmentIntegration from '@segment/analytics.js-integration-segmentio';
 ```
 
-3- Initialize Segment and add Segment's own integration 
+3- Initialize Segment and add Segment's own integration
+
 ```javascript
 // instantiate the library
 const analytics = new Analytics();
 
-// add Segment's own integration ( or any other device mode integration ) 
+// add Segment's own integration ( or any other device mode integration )
 analytics.use(SegmentIntegration);
 
-// define the integration settings object. 
-// Since we are using only Segment integration in this example, we only have 
+// define the integration settings object.
+// Since we are using only Segment integration in this example, we only have
 // "Segment.io" in the integrationSettings object
 const integrationSettings = {
-  "Segment.io": {
-    apiKey: "<YOUR SEGMENT WRITE KEY>",
+  'Segment.io': {
+    apiKey: '<YOUR SEGMENT WRITE KEY>',
     retryQueue: true,
-    addBundledMetadata: true
-  }
+    addBundledMetadata: true,
+  },
 };
-
 
 // Initialize the library
 analytics.initialize(integrationSettings);
 
-// Happy tracking! 
+// Happy tracking!
 analytics.track('🚀');
 ```
 

--- a/lib/normalize.ts
+++ b/lib/normalize.ts
@@ -12,7 +12,7 @@ var each = require('./utils/each');
 var includes = require('@ndhoule/includes');
 var map = require('./utils/map');
 var type = require('component-type');
-var uuid = require('uuid/v4');
+var { v4: uuidv4 } = require('uuid');
 var md5 = require('spark-md5').hash;
 
 /**
@@ -45,7 +45,7 @@ interface NormalizedMessage {
 }
 
 function normalize(msg: Message, list: Array<any>): NormalizedMessage {
-  var lower = map(function(s) {
+  var lower = map(function (s) {
     return s.toLowerCase();
   }, list);
   var opts: Message = msg.options || {};
@@ -59,7 +59,7 @@ function normalize(msg: Message, list: Array<any>): NormalizedMessage {
   debug('<-', msg);
 
   // integrations.
-  each(function(value: string, key: string) {
+  each(function (value: string, key: string) {
     if (!integration(key)) return;
     if (!has.call(integrations, key)) integrations[key] = value;
     delete opts[key];
@@ -67,7 +67,7 @@ function normalize(msg: Message, list: Array<any>): NormalizedMessage {
 
   // providers.
   delete opts.providers;
-  each(function(value: string, key: string) {
+  each(function (value: string, key: string) {
     if (!integration(key)) return;
     if (type(integrations[key]) === 'object') return;
     if (has.call(integrations, key) && typeof providers[key] === 'boolean')
@@ -77,7 +77,7 @@ function normalize(msg: Message, list: Array<any>): NormalizedMessage {
 
   // move all toplevel options to msg
   // and the rest to context.
-  each(function(_value: any, key: string | number) {
+  each(function (_value: any, key: string | number) {
     if (includes(key, toplevel)) {
       ret[key] = opts[key];
     } else {
@@ -86,7 +86,7 @@ function normalize(msg: Message, list: Array<any>): NormalizedMessage {
   }, opts);
 
   // generate and attach a messageId to msg
-  msg.messageId = 'ajs-' + md5(window.JSON.stringify(msg) + uuid());
+  msg.messageId = 'ajs-' + md5(window.JSON.stringify(msg) + uuidv4());
 
   // cleanup
   delete msg.options;

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -11,7 +11,7 @@ var cookie = require('./cookie');
 var debug = require('debug')('analytics:user');
 var inherit = require('inherits');
 var rawCookie = require('@segment/cookie');
-var uuid = require('uuid');
+var { v4: uuidv4 } = require('uuid');
 var localStorage = require('./store');
 
 /**
@@ -38,11 +38,11 @@ User.defaults = {
   persist: true,
   cookie: {
     key: 'ajs_user_id',
-    oldKey: 'ajs_user'
+    oldKey: 'ajs_user',
   },
   localStorage: {
-    key: 'ajs_user_traits'
-  }
+    key: 'ajs_user_traits',
+  },
 };
 
 /**
@@ -86,7 +86,7 @@ inherit(User, Entity);
  * assert.notEqual(anonymousId, user.anonymousId());
  */
 
-User.prototype.id = function(id?: string): string | undefined {
+User.prototype.id = function (id?: string): string | undefined {
   var prev = this._getId();
   var ret = Entity.prototype.id.apply(this, arguments);
   if (prev == null) return ret;
@@ -106,7 +106,7 @@ User.prototype.id = function(id?: string): string | undefined {
  * @return {String|User}
  */
 
-User.prototype.anonymousId = function(anonymousId?: string): string | User {
+User.prototype.anonymousId = function (anonymousId?: string): string | User {
   var store = this.storage();
 
   // set / remove
@@ -147,7 +147,7 @@ User.prototype.anonymousId = function(anonymousId?: string): string | User {
   }
 
   // empty
-  anonymousId = uuid.v4();
+  anonymousId = uuidv4();
   store.set('ajs_anonymous_id', anonymousId);
   this._setAnonymousIdInLocalStorage(anonymousId);
   return store.get('ajs_anonymous_id');
@@ -157,7 +157,7 @@ User.prototype.anonymousId = function(anonymousId?: string): string | User {
  * Set the user's `anonymousid` in local storage.
  */
 
-User.prototype._setAnonymousIdInLocalStorage = function(id: string) {
+User.prototype._setAnonymousIdInLocalStorage = function (id: string) {
   if (!this._options.localStorageFallbackDisabled) {
     localStorage.set('ajs_anonymous_id', id);
   }
@@ -167,7 +167,7 @@ User.prototype._setAnonymousIdInLocalStorage = function(id: string) {
  * Remove anonymous id on logout too.
  */
 
-User.prototype.logout = function() {
+User.prototype.logout = function () {
   Entity.prototype.logout.call(this);
   this.anonymousId(null);
 };
@@ -176,7 +176,7 @@ User.prototype.logout = function() {
  * Load saved user `id` or `traits` from storage.
  */
 
-User.prototype.load = function() {
+User.prototype.load = function () {
   if (this._loadOldCookie()) return;
   Entity.prototype.load.call(this);
 };
@@ -187,7 +187,7 @@ User.prototype.load = function() {
  * @api private
  */
 
-User.prototype._loadOldCookie = function(): boolean {
+User.prototype._loadOldCookie = function (): boolean {
   var user = cookie.get(this._options.cookie.oldKey);
   if (!user) return false;
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "package-json-versionify": "^1.0.4",
     "segmentio-facade": "^3.2.7",
     "spark-md5": "^2.0.2",
-    "uuid": "^3.4.0"
+    "uuid": "^8.0.0"
   },
   "devDependencies": {
     "@codeceptjs/mock-request": "^0.3.0",


### PR DESCRIPTION
## Description

I am getting this warning using Yarn 2
```
uuid@npm:3.4.0 is deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
```
I realized this package is using `uuid@3.4.0` and I think is a good idea to upgrade it to v8, no breaking changes included.
I have followed this doc https://github.com/uuidjs/uuid#upgrading-from-uuid3

## Test plan

<!-- Provide all possible documentation: screenshots, sh commands, etc.
For change control purposes, use the following pattern:

- Testing completed successfully using <how did you test, environment>; or
- Testing not required because <explain why you think testing isn't needed>
-->

## Release plan

<!-- Update the HISTORY.md file if we need to generate a new version of AJS for your changes.

If not, just add the following line with an explanation:
New version is not required because <verbose explantaion - for example 'it's a dev-only change'>.
-->

## Checklist

- [ ] Thorough explanation of the issue/solution, and a link to the related issue
- [ ] CI tests are passing
- [ ] Unit tests were written for any new code
- [x] Code coverage is at least maintained, or increased.
